### PR TITLE
Ignore targets missing from graph

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
@@ -5,7 +5,6 @@ import java.io.PrintWriter
 import scala.collection.JavaConverters._
 
 import com.twitter.multiversion.Build.QueryResult
-import com.twitter.multiversion.Build.Target
 import moped.annotations.CommandName
 import moped.annotations.PositionalArguments
 import moped.cli.Application
@@ -15,7 +14,6 @@ import moped.json.Result
 import moped.json.ValueResult
 import moped.progressbars.InteractiveProgressBar
 import moped.progressbars.ProcessRenderer
-import moped.reporters.Diagnostic
 import multiversion.diagnostics.MultidepsEnrichments._
 import multiversion.indexes.DependenciesIndex
 import multiversion.indexes.TargetIndex
@@ -88,7 +86,8 @@ case class LintCommand(
               if tdep.dependency != Some(dep)
             } yield tdep
         }.toSet
-        val redundant = errors.foreach {
+
+        errors.foreach {
           case (module, versions) =>
             val deps = versions
               .map(v => SimpleDependency(module, v))
@@ -96,26 +95,13 @@ case class LintCommand(
             if (!deps.exists(isTransitive)) {
               app.reporter.error(
                 s"target '$root' depends on conflicting versions of the 3rdparty dependency '${module.repr}:{${versions.commas}}'.\n" +
-                  s"\tTo fix this problem, the dependency list of this target so that it only depends on one version of the 3rdparty module '${module.repr}'"
+                  s"\tTo fix this problem, modify the dependency list of this target so that it only depends on one version of the 3rdparty module '${module.repr}'"
               )
             }
         }
       }
-      ()
     }
   }
-
-  private def lintTarget(
-      t: Target,
-      index: DependenciesIndex
-  ): Option[Diagnostic] = {
-    pprint.log(t.getRule().getName())
-    // pprint.log(deps)
-    // pprint.log(tags)
-    // pprint.log(dependency)
-    None
-  }
-
 }
 
 object LintCommand {

--- a/multiversion/src/main/scala/multiversion/indexes/DependenciesIndex.scala
+++ b/multiversion/src/main/scala/multiversion/indexes/DependenciesIndex.scala
@@ -28,7 +28,10 @@ class DependenciesIndex(query: QueryResult) {
     }
   }
   def dependencies(target: String): Set[TargetIndex] = {
-    dependencies(byName(target))
+    byName.get(target) match {
+      case Some(targetIndex) => dependencies(targetIndex)
+      case None              => Set.empty
+    }
   }
   def dependencies(target: TargetIndex): Set[TargetIndex] = {
     // NOTE: not stack safe

--- a/multiversion/src/main/scala/multiversion/indexes/DependenciesIndex.scala
+++ b/multiversion/src/main/scala/multiversion/indexes/DependenciesIndex.scala
@@ -31,10 +31,7 @@ class DependenciesIndex(query: QueryResult) {
     dependencies(byName(target))
   }
   def dependencies(target: TargetIndex): Set[TargetIndex] = {
-    deps.get(target.name) match {
-      case Some(value) => value
-      // NOTE(olafur): not stack safe
-      case None => Set(target) ++ target.deps.flatMap(dependencies)
-    }
+    // NOTE: not stack safe
+    deps.getOrElseUpdate(target.name, Set(target) ++ target.deps.flatMap(dependencies))
   }
 }


### PR DESCRIPTION
Depending on the query that was used to create a `DependenciesIndex`,
targets can have dependencies to targets that are not defined in the
query results.

For instance, the query executed by the lint command reads:

    allpaths(foo, @maven//:all)

If `foo` has a dependency on a target `bar`, which has no dependency on
any of `@maven//:all`, then `bar` will not be defined in the results of
the query. Getting the `dependencies` of `foo` would then cause a crash
in multiversion.

This commit changes `DependenciesIndex` so that the missing targets are
simply ignored. Because these targets do not appear on any path ending
in any of `@maven//:all`, then they cannot introduce conflicts, and
ignoring them is safe.