### PR TITLE
Use Relaxed reconciliation by default

### DIFF
--- a/scripts/post-download.sh
+++ b/scripts/post-download.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+rm target/dist-macOS.zip 2> /dev/null || true
+rm target/dist-Linux.zip 2> /dev/null || true
+cp $HOME/Downloads/dist-macOS.zip target/dist-macOS.zip
+cp $HOME/Downloads/dist-Linux.zip target/dist-Linux.zip
+cd target/
+unzip dist-macOS.zip
+chmod +x multiversion
+mv multiversion multiversion-x64_64-apple-darwin
+unzip dist-Linux.zip
+chmod +x multiversion
+mv multiversion multiversion-x64_64-pc-linux
+cd ..


### PR DESCRIPTION
Ref sbt/sbt#4950

Coursier by default uses conflict resolution logic that uses latest-wins for specific versions (for example `commons-io:commons-io:1.1` vs `commons-io:commons-io:2.6`) similar to Ivy, but strict for version ranges (for example `org.webjars.npm:entities:[1.0,1.1`) vs `org.webjars.npm:entities:[1.1.1,2)`), unlike Ivy. This creates seemingly arbitrary conflicts.

Note that this has nothing to do with Semantic Versioning as seen in the examples above, 2.6 would evict 1.1 if it were a specific version; and `[1.1.1,2)` won't evict `[1.0,1.1)`.