### PR TITLE
Emit YAML linting report

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
@@ -119,7 +119,7 @@ case class LintCommand(
         .map(p => if (p.isAbsolute()) p else app.env.workingDirectory.resolve(p))
         .foreach { out =>
           val docs = lintResults.filter(_.conflicts.nonEmpty).map(_.toDoc)
-          val rendered = Doc.intercalate(Doc.line, docs).render(120)
+          val rendered = Doc.intercalate(Doc.line, docs).render(Int.MaxValue)
           Files.createDirectories(out.getParent())
           Files.write(out, rendered.getBytes(StandardCharsets.UTF_8))
         }

--- a/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
@@ -1,11 +1,15 @@
 package multiversion.commands
 
 import java.io.PrintWriter
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 
 import scala.collection.JavaConverters._
 
 import com.twitter.multiversion.Build.QueryResult
 import moped.annotations.CommandName
+import moped.annotations.Description
 import moped.annotations.PositionalArguments
 import moped.cli.Application
 import moped.cli.Command
@@ -19,10 +23,13 @@ import multiversion.indexes.DependenciesIndex
 import multiversion.indexes.TargetIndex
 import multiversion.loggers.ProgressBars
 import multiversion.loggers.StaticProgressRenderer
+import multiversion.outputs.LintOutput
 import multiversion.resolvers.SimpleDependency
+import org.typelevel.paiges.Doc
 
 @CommandName("lint")
 case class LintCommand(
+    @Description("File to write lint report") lintReportPath: Option[Path] = None,
     @PositionalArguments queryExpressions: List[String] = Nil,
     app: Application = Application.default
 ) extends Command {
@@ -69,7 +76,7 @@ case class LintCommand(
     } yield {
       val roots = rootsResult.getTargetList().asScala.map(_.getRule().getName())
       val index = new DependenciesIndex(result)
-      roots.foreach { root =>
+      val lintResults = roots.map { root =>
         val deps = index.dependencies(root)
         val errors = deps.groupBy(_.dependency.map(_.module)).collect {
           case (Some(dep), ts) if ts.size > 1 =>
@@ -87,19 +94,35 @@ case class LintCommand(
             } yield tdep
         }.toSet
 
-        errors.foreach {
+        val reportedErrors = errors.filter {
           case (module, versions) =>
             val deps = versions
               .map(v => SimpleDependency(module, v))
               .flatMap(index.byDependency.get(_))
-            if (!deps.exists(isTransitive)) {
-              app.reporter.error(
-                s"target '$root' depends on conflicting versions of the 3rdparty dependency '${module.repr}:{${versions.commas}}'.\n" +
-                  s"\tTo fix this problem, modify the dependency list of this target so that it only depends on one version of the 3rdparty module '${module.repr}'"
-              )
-            }
+            !deps.exists(isTransitive)
         }
+
+        LintOutput(root, reportedErrors)
       }
+
+      for {
+        LintOutput(root, errors) <- lintResults
+        (module, versions) <- errors
+      } {
+        app.reporter.error(
+          s"target '$root' depends on conflicting versions of the 3rdparty dependency '${module.repr}:{${versions.commas}}'.\n" +
+            s"\tTo fix this problem, modify the dependency list of this target so that it only depends on one version of the 3rdparty module '${module.repr}'"
+        )
+      }
+
+      lintReportPath
+        .map(p => if (p.isAbsolute()) p else app.env.workingDirectory.resolve(p))
+        .foreach { out =>
+          val docs = lintResults.filter(_.conflicts.nonEmpty).map(_.toDoc)
+          val rendered = Doc.intercalate(Doc.line, docs).render(120)
+          Files.createDirectories(out.getParent())
+          Files.write(out, rendered.getBytes(StandardCharsets.UTF_8))
+        }
     }
   }
 }

--- a/multiversion/src/main/scala/multiversion/outputs/Docs.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/Docs.scala
@@ -18,6 +18,8 @@ object Docs {
   val close: Doc = Doc.char(')')
   val openBracket: Doc = Doc.char('[')
   val closeBracket: Doc = Doc.char(']')
+  val dash: Doc = Doc.char('-')
+  val colon: Doc = Doc.char(':')
   object emoji {
     val success: Doc = colors.green + Doc.text("✔ ") + colors.reset
     val error: Doc = Doc.text("❗")

--- a/multiversion/src/main/scala/multiversion/outputs/Docs.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/Docs.scala
@@ -16,9 +16,10 @@ object Docs {
   val quote: Doc = Doc.char('"')
   val open: Doc = Doc.char('(')
   val close: Doc = Doc.char(')')
+  val openBrace: Doc = Doc.char('{')
+  val closeBrace: Doc = Doc.char('}')
   val openBracket: Doc = Doc.char('[')
   val closeBracket: Doc = Doc.char(']')
-  val dash: Doc = Doc.char('-')
   val colon: Doc = Doc.char(':')
   object emoji {
     val success: Doc = colors.green + Doc.text("✔ ") + colors.reset

--- a/multiversion/src/main/scala/multiversion/outputs/LintOutput.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/LintOutput.scala
@@ -15,9 +15,10 @@ final case class LintOutput(
       .sortBy(_._1)
     val conflictDocs = sortedConflicts.map {
       case (module, versions) =>
-        Doc.spaces(2) + Docs.dash + Doc.space + Docs.literal(module) + Docs.colon + Doc.space + Docs
-          .array(versions: _*)
+        Docs.literal(module) + Docs.colon + Doc.space + Docs.array(versions: _*)
     }
-    Docs.literal(root) + Docs.colon + Doc.line + Doc.intercalate(Doc.line, conflictDocs)
+    Docs.literal(root) + Docs.colon + Doc.space + Doc
+      .intercalate(Doc.comma + Doc.space, conflictDocs)
+      .tightBracketBy(Docs.openBrace, Docs.closeBrace)
   }
 }

--- a/multiversion/src/main/scala/multiversion/outputs/LintOutput.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/LintOutput.scala
@@ -1,0 +1,23 @@
+package multiversion.outputs
+
+import multiversion.resolvers.SimpleModule
+import org.typelevel.paiges.Doc
+
+final case class LintOutput(
+    root: String,
+    conflicts: Map[SimpleModule, Set[String]]
+) {
+  def toDoc: Doc = {
+    // Sort the conflicts to ensure the output is stable.
+    val sortedConflicts = conflicts
+      .map { case (module, versions) => module.repr -> versions.toList.sorted }
+      .toList
+      .sortBy(_._1)
+    val conflictDocs = sortedConflicts.map {
+      case (module, versions) =>
+        Doc.spaces(2) + Docs.dash + Doc.space + Docs.literal(module) + Docs.colon + Doc.space + Docs
+          .array(versions: _*)
+    }
+    Docs.literal(root) + Docs.colon + Doc.line + Doc.intercalate(Doc.line, conflictDocs)
+  }
+}


### PR DESCRIPTION
The lint command now emits a YAML linting report at the location
specified by `--lint-report-path` when the option is set.

The option can also be set from `export` and `pants-export`.

The report contains the roots that failed and the name and versions of
the conflicting dependencies:

```
"//my:target":
  - "com.acme:other-dependency": ["1.1", "2.0"]
  - "my.org:my-dependency": ["1.0", "1.1"]
"//my/other:target":
  - "org:dep": ["0.1", "0.2", "1.0"]
```

Updated to:
```
"//my:target": {"com.acme:other-dependency": ["1.1", "2.0"], "my.org:my-dependency": ["1.0", "1.1"]}
"//my/other:target": {"org:dep": ["0.1", "0.2", "1.0"]}
```