### PR TITLE
Support pending targets in linting

### DIFF
--- a/multiversion/src/main/scala/multiversion/BazelUtil.scala
+++ b/multiversion/src/main/scala/multiversion/BazelUtil.scala
@@ -1,0 +1,45 @@
+package multiversion
+
+import java.io.PrintWriter
+import java.nio.file.Path
+
+import geny.ByteData
+import moped.cli.Application
+import moped.json.Result
+import moped.json.ValueResult
+import moped.progressbars.InteractiveProgressBar
+import moped.progressbars.ProcessRenderer
+import multiversion.loggers.ProgressBars
+import multiversion.loggers.StaticProgressRenderer
+
+object BazelUtil {
+
+  /** The path to the root of the package owning the given label. */
+  def packageRoot(app: Application, label: String): Result[Path] = {
+    val command = List(
+      "query",
+      label,
+      "--output",
+      "package"
+    )
+
+    bazel(app, command).map { out =>
+      app.env.workingDirectory.resolve(out.trim())
+    }
+  }
+
+  def bazel(app: Application, command: List[String]): Result[ByteData.Chunks] = {
+    val pr0 = new ProcessRenderer(command, command, clock = app.env.clock)
+    val pr = StaticProgressRenderer.ifAnsiDisabled(pr0, app.env.isColorEnabled)
+    val pb = new InteractiveProgressBar(out = new PrintWriter(app.env.standardError), renderer = pr)
+    val process = ProgressBars.run(pb) {
+      os.proc("bazel" :: command)
+        .call(cwd = os.Path(app.env.workingDirectory), stderr = pr0.output, check = false)
+    }
+    if (process.exitCode == 0) {
+      ValueResult(process.out)
+    } else {
+      pr0.asErrorResult(process.exitCode)
+    }
+  }
+}

--- a/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
@@ -1,6 +1,5 @@
 package multiversion.commands
 
-import java.io.PrintWriter
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
@@ -10,19 +9,16 @@ import scala.collection.JavaConverters._
 import com.twitter.multiversion.Build.QueryResult
 import moped.annotations.CommandName
 import moped.annotations.Description
+import moped.annotations.Flag
 import moped.annotations.PositionalArguments
 import moped.cli.Application
 import moped.cli.Command
 import moped.cli.CommandParser
 import moped.json.Result
-import moped.json.ValueResult
-import moped.progressbars.InteractiveProgressBar
-import moped.progressbars.ProcessRenderer
+import multiversion.BazelUtil
 import multiversion.diagnostics.MultidepsEnrichments._
 import multiversion.indexes.DependenciesIndex
 import multiversion.indexes.TargetIndex
-import multiversion.loggers.ProgressBars
-import multiversion.loggers.StaticProgressRenderer
 import multiversion.outputs.LintOutput
 import multiversion.resolvers.SimpleDependency
 import org.typelevel.paiges.Doc
@@ -30,39 +26,21 @@ import org.typelevel.paiges.Doc
 @CommandName("lint")
 case class LintCommand(
     @Description("File to write lint report") lintReportPath: Option[Path] = None,
+    @Description("Automatically mark failing target as pending") @Flag lintMarkPending: Boolean =
+      false,
     @PositionalArguments queryExpressions: List[String] = Nil,
     app: Application = Application.default
 ) extends Command {
   private def runQuery(queryExpression: String): Result[QueryResult] = {
     val command = List(
-      "bazel",
       "query",
       queryExpression,
       "--noimplicit_deps",
       "--notool_deps",
       "--output=proto"
     )
-    val pr0 = new ProcessRenderer(command, command, clock = app.env.clock)
-    val pr = StaticProgressRenderer.ifAnsiDisabled(
-      pr0,
-      app.env.isColorEnabled
-    )
-    val pb = new InteractiveProgressBar(
-      out = new PrintWriter(app.env.standardError),
-      renderer = pr
-    )
-    val process = ProgressBars.run(pb) {
-      os.proc(command)
-        .call(
-          cwd = os.Path(app.env.workingDirectory),
-          stderr = pr0.output,
-          check = false
-        )
-    }
-    if (process.exitCode == 0) {
-      ValueResult(QueryResult.parseFrom(process.out.bytes))
-    } else {
-      pr0.asErrorResult(process.exitCode)
+    BazelUtil.bazel(app, command).map { out =>
+      QueryResult.parseFrom(out.bytes)
     }
   }
 
@@ -102,14 +80,18 @@ case class LintCommand(
             !deps.exists(isTransitive)
         }
 
-        LintOutput(root, reportedErrors)
+        val isFailure = reportedErrors.nonEmpty && !isPending(app, root)
+        LintOutput(root, reportedErrors, isFailure)
       }
 
       for {
-        LintOutput(root, errors) <- lintResults
+        LintOutput(root, errors, isFailure) <- lintResults
+        log =
+          if (isFailure) app.reporter.error _
+          else (s: String) => app.reporter.warning(s"(Pending) $s")
         (module, versions) <- errors
       } {
-        app.reporter.error(
+        log(
           s"target '$root' depends on conflicting versions of the 3rdparty dependency '${module.repr}:{${versions.commas}}'.\n" +
             s"\tTo fix this problem, modify the dependency list of this target so that it only depends on one version of the 3rdparty module '${module.repr}'"
         )
@@ -124,6 +106,20 @@ case class LintCommand(
           Files.write(out, rendered.getBytes(StandardCharsets.UTF_8))
         }
     }
+  }
+
+  private def isPending(app: Application, label: String): Boolean = {
+    BazelUtil
+      .packageRoot(app, label)
+      .map { path =>
+        val pendingFile = path.resolve("PENDING")
+        if (Files.isRegularFile(pendingFile)) true
+        else if (lintMarkPending) {
+          Files.createFile(pendingFile)
+          true
+        } else false
+      }
+      .getOrElse(false)
   }
 }
 

--- a/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
@@ -112,10 +112,11 @@ case class LintCommand(
     BazelUtil
       .packageRoot(app, label)
       .map { path =>
+        val pendingBazelFile = path.resolve("PENDING.bazel")
         val pendingFile = path.resolve("PENDING")
-        if (Files.isRegularFile(pendingFile)) true
+        if (Files.isRegularFile(pendingBazelFile) || Files.isRegularFile(pendingFile)) true
         else if (lintMarkPending) {
-          Files.createFile(pendingFile)
+          Files.createFile(pendingBazelFile)
           true
         } else false
       }

--- a/multiversion/src/main/scala/multiversion/outputs/Docs.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/Docs.scala
@@ -21,6 +21,15 @@ object Docs {
   val openBracket: Doc = Doc.char('[')
   val closeBracket: Doc = Doc.char(']')
   val colon: Doc = Doc.char(':')
+  def obj(entries: Iterable[(String, Doc)]): Doc = {
+    val mappings = entries.map {
+      case (key, value) =>
+        literal(key) + colon + Doc.space + value
+    }
+    Doc
+      .intercalate(Doc.comma + Doc.space, mappings)
+      .tightBracketBy(openBrace, closeBrace)
+  }
   object emoji {
     val success: Doc = colors.green + Doc.text("✔ ") + colors.reset
     val error: Doc = Doc.text("❗")


### PR DESCRIPTION
A target is said to be pending if its BUILD file has a sibling named
`PENDING`. When linting, pending targets that have conflicting
dependencies will report a warning instead of an error. Linting will
succeed if only pending targets report dependency conflicts.

The YAML report format is changed to:

```
"//my/target:name" {"failure": <true or false>, "conflicts": {"org:name": ["1.0", "2.0"], ...}}
```

The `failure` field is always false for pending targets.