### PR TITLE
Persist classifier and improve version comparison

### DIFF
--- a/multiversion/src/main/scala/multiversion/outputs/ArtifactOutput.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/ArtifactOutput.scala
@@ -95,16 +95,20 @@ object ArtifactOutput {
         "jars" -> Docs.array(mavenLabel),
         "deps" -> Docs.array(depsRef: _*),
         "exports" -> Docs.array(depsRef: _*),
-        "tags" -> Docs.array(
-          s"jvm_module=${dependency.module.repr}",
-          s"jvm_version=${dependency.version}"
-        ),
+        "tags" -> Docs.array(tags(dependency): _*),
         "visibility" -> Docs.array("//visibility:public")
       )
 
     genrule.toDoc /
       scalaImport.toDoc
   }
+
+  def tags(dep: Dependency): List[String] =
+    List(s"jvm_module=${dep.module.repr}", s"jvm_version=${dep.version}") ::: {
+      if (dep.publication.classifier.nonEmpty)
+        List(s"jvm_classifier=${dep.publication.classifier.value}")
+      else Nil
+    }
 
   def buildEvictedDoc(
       dep: Dependency,
@@ -122,11 +126,7 @@ object ArtifactOutput {
         "jars" -> Docs.array(),
         "deps" -> Docs.array(depsRef: _*),
         "exports" -> Docs.array(depsRef: _*),
-        "tags" -> Docs.array(
-          s"jvm_module=${dep.module.repr}",
-          s"jvm_version=${dep.version}",
-          s"evicted=True"
-        ),
+        "tags" -> Docs.array(tags(dep) ::: List("evicted=True"): _*),
         "visibility" -> Docs.array("//visibility:public")
       )
     scalaImport.toDoc

--- a/multiversion/src/main/scala/multiversion/outputs/LintOutput.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/LintOutput.scala
@@ -1,19 +1,20 @@
 package multiversion.outputs
 
+import multiversion.resolvers.SimpleDependency
 import multiversion.resolvers.SimpleModule
 import org.typelevel.paiges.Doc
 
 final case class LintOutput(
     root: String,
-    conflicts: Map[SimpleModule, Set[String]],
+    conflicts: Map[SimpleModule, Set[SimpleDependency]],
     isFailure: Boolean
 ) {
   def toDoc: Doc = {
     // Sort the conflicts to ensure the output is stable.
     val sortedConflicts = conflicts
       .map {
-        case (module, versions) =>
-          val versionsDoc = Docs.array(versions.toList.sorted: _*)
+        case (module, deps) =>
+          val versionsDoc = Docs.array(deps.toList.map(_.version).sorted: _*)
           module.repr -> versionsDoc
       }
       .toList

--- a/multiversion/src/main/scala/multiversion/resolvers/SimpleDependency.scala
+++ b/multiversion/src/main/scala/multiversion/resolvers/SimpleDependency.scala
@@ -4,8 +4,17 @@ import scala.util.hashing.MurmurHash3
 
 case class SimpleDependency(
     module: SimpleModule,
-    version: String
+    version: String,
+    classifier: Option[String],
 ) {
-  def repr: String = s"${module.repr}:$version"
+  private[this] def classifierStr: String =
+    classifier match {
+      case Some(x) => s"-$x"
+      case _       => ""
+    }
+  // https://repo1.maven.org/maven2/org/apache/kafka/kafka-clients/2.4.0/ lists
+  // kafka-clients-2.4.0-test.jar
+  def repr: String = s"${module.repr}:$version${classifierStr}"
+
   override lazy val hashCode: Int = MurmurHash3.productHash(this)
 }

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -28,6 +28,16 @@ class ExportCommandSuite extends tests.BaseSuite {
   )
 
   checkDeps(
+    "netty",
+    """|  - dependency: io.netty:netty:3.10.1.Final
+       |  - dependency: io.netty:netty:3.7.0.Final
+       |""".stripMargin,
+    queryArgs = allGenrules,
+    expectedQuery = """|@maven//:genrules/io.netty_netty_3.10.1.Final
+                       |""".stripMargin
+  )
+
+  checkDeps(
     "basic",
     """|  - dependency: com.google.guava:guava:29.0-jre
        |  - dependency: org.eclipse.lsp4j:org.eclipse.lsp4j:0.9.0
@@ -61,7 +71,7 @@ class ExportCommandSuite extends tests.BaseSuite {
         |    versionScheme: pvp
         |  - dependency: com.lihaoyi:pprint_2.12:0.5.9
         |${scalaLibrary("MyApp.scala", "object MyApp { val x = 42 }")}
-        |""".stripMargin
+        |""".stripMargin,
   )
 
   checkDeps(


### PR DESCRIPTION
Ref https://github.com/coursier/versions/issues/10
`compat.isCompatible(...)` doesn't work when the version number includes
weird alphabet tags in there like `3.10.1.Final`.
This tries to work round the issue by calculating the minimum compatible
versions and comparing the two.