### PR TITLE
Fix version reconciliation

### DIFF
--- a/tests/src/test/scala/tests/commands/ResolutionTest.scala
+++ b/tests/src/test/scala/tests/commands/ResolutionTest.scala
@@ -35,6 +35,14 @@ class ResolutionTest extends tests.BaseSuite {
     assert(vs.values.toList.distinct.size == 1)
   }
 
+  test("resolveVersions") {
+    val vs = ResolutionIndex.resolveVersions(
+      Set("2.11.2", "2.6.7.1", "2.9.9", "2.10.0", "2.10.2", "2.8.4"),
+      VersionCompatibility.EarlySemVer
+    )
+    assertEquals(vs.head, "2.11.2")
+  }
+
   def jodaTime(v: String): Dependency =
     Dependency(
       Module(Organization("joda-time"), ModuleName("joda-time"), Map.empty),


### PR DESCRIPTION
For some reason 2.10.2 was winning over 2.11.2 of some libraries. Calling `toSet` seems to fix that. Does that mean there's a bug in the implementation of scala-library?