### PR TITLE
Fix false positive on linting

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
@@ -54,7 +54,7 @@ case class LintCommand(
       val lintResults = roots.map { root =>
         val deps = index.dependencies(root)
         val errors = deps.groupBy(_.dependency.map(_.module)).collect {
-          case (Some(dep), ts) if ts.size > 1 =>
+          case (Some(dep), ts) if ts.flatMap(_.dependency.map(_.version).toSet).toSet.size > 1 =>
             dep -> ts.collect {
               case TargetIndex(_, _, _, Some(dep)) => dep
             }

--- a/multiversion/src/main/scala/multiversion/diagnostics/ConflictingTransitiveDependencyDiagnostic.scala
+++ b/multiversion/src/main/scala/multiversion/diagnostics/ConflictingTransitiveDependencyDiagnostic.scala
@@ -26,11 +26,17 @@ class ConflictingTransitiveDependencyDiagnostic(
     def pretty(xs: Iterable[Any]): String =
       if (xs.isEmpty) ""
       else xs.mkString(" ", ", ", "")
+    val depsStr =
+      (foundVersions
+        .map { v =>
+          s"'dependency = ${Dependency(module, v).repr}'"
+        })
+        .mkString(", ")
     val toFix =
       if (pos.isNone)
-        s"add 'dependencies' to the root dependencies OR create a new root dependency for the module '${module.repr}'."
+        s"add $depsStr to the root dependencies OR create a new root dependency for the module '${module.repr}'."
       else
-        "add 'dependencies = ''' to the root dependencies OR add 'targets' to the transitive dependency."
+        s"add $depsStr to the root dependencies OR add 'targets' to the transitive dependency."
     val okRootsStr = pretty(okRoots.distinct.take(20).map(_.repr))
     val okTargetsStr = pretty(okDepsConfig.distinct.take(20).flatMap(_.targets))
     val unpopularRootsStr = pretty(unpopularRoots.distinct.map(_.repr))

--- a/tests/src/main/scala/tests/BaseSuite.scala
+++ b/tests/src/main/scala/tests/BaseSuite.scala
@@ -161,7 +161,8 @@ abstract class BaseSuite extends MopedSuite(MultiVersion.app) {
       arguments: => List[String],
       expectedOutput: String,
       expectedExit: Int = 0,
-      workingDirectoryLayout: String = ""
+      workingDirectoryLayout: String = "",
+      lintArgs: List[String] = Nil,
   )(implicit loc: munit.Location): Unit = {
     if (workingDirectoryLayout.nonEmpty) {
       FileLayout.fromString(workingDirectoryLayout, workingDirectory)
@@ -170,5 +171,9 @@ abstract class BaseSuite extends MopedSuite(MultiVersion.app) {
     val exit = app().run(arguments)
     assertEquals(exit, expectedExit, clues(app.capturedOutput))
     assertNoDiff(app.capturedOutput, expectedOutput)
+    if (lintArgs.nonEmpty) {
+      val exit = app().run(lintArgs)
+      assertEquals(exit, 0, clues(app.capturedOutput))
+    }
   }
 }

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -42,8 +42,7 @@ class ExportCommandSuite extends tests.BaseSuite {
     """|  - dependency: com.google.guava:guava:29.0-jre
        |  - dependency: org.eclipse.lsp4j:org.eclipse.lsp4j:0.9.0
        |""".stripMargin,
-    expectedOutput =
-      """|/workingDirectory/3rdparty.yaml:3:16 error: transitive dependency 'com.google.guava:guava' has conflicting versions.
+    expectedOutput = """|/workingDirectory/3rdparty.yaml:3:16 error: transitive dependency 'com.google.guava:guava' has conflicting versions.
          |       found versions: 27.1-jre
          |    declared versions: 29.0-jre
          |      popular version: 29.0-jre
@@ -51,7 +50,7 @@ class ExportCommandSuite extends tests.BaseSuite {
          |           ok targets:
          |       unpopular deps: org.eclipse.lsp4j:org.eclipse.lsp4j:0.9.0
          |    unpopular targets:
-         |  To fix this problem, add 'dependencies = ''' to the root dependencies OR add 'targets' to the transitive dependency.
+         |  To fix this problem, add 'dependency = com.google.guava:guava:27.1-jre' to the root dependencies OR add 'targets' to the transitive dependency.
          |  - dependency: com.google.guava:guava:29.0-jre
          |                ^""".stripMargin,
     expectedExit = 1

--- a/tests/src/test/scala/tests/commands/LintCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/LintCommandSuite.scala
@@ -22,4 +22,34 @@ class LintCommandSuite extends BaseSuite {
                                    |""".stripMargin
     )
   }
+
+  test("classifier") {
+    checkCommand(
+      arguments = List("export"),
+      expectedOutput = """|✔ Generated '/workingDirectory/3rdparty/jvm_deps.bzl'
+                          |""".stripMargin,
+      workingDirectoryLayout = s"""|/3rdparty.yaml
+                                   |scala: 2.12.12
+                                   |dependencies:
+                                   |  - dependency: org.apache.kafka:kafka_2.12:2.4.1
+                                   |    versionScheme: pvp
+                                   |  - dependency: org.apache.kafka:kafka_2.12:2.4.1
+                                   |    versionScheme: pvp
+                                   |    classifier: test
+                                   |/foo/BUILD
+                                   |load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library", "scala_binary")
+                                   |
+                                   |scala_library(
+                                   |  name = "foo",
+                                   |  srcs = [],
+                                   |  deps = [
+                                   |    "@maven//:org.apache.kafka_kafka_2.12_2.4.1",
+                                   |    "@maven//:org.apache.kafka_kafka_2.12_2.4.1_test",
+                                   |  ],
+                                   |)
+                                   |$bazelWorkspace
+                                   |""".stripMargin,
+      lintArgs = List("lint", "//foo:foo"),
+    )
+  }
 }


### PR DESCRIPTION
Prior to this change, lint was detecting two dependencies to be a conflict even though the version numbers were the same, but with different classifiers.