### PR TITLE
Allow Coursier cache to be specified

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/PantsExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/PantsExportCommand.scala
@@ -27,8 +27,6 @@ final case class PantsExportCommand(
     @PositionalArguments()
     pantsTargets: List[String] = List("3rdparty/jvm::"),
     cwd: Option[Path] = None,
-    lint: Boolean = false,
-    cache: Option[Path] = None,
     @Inline
     save: ExportCommand = ExportCommand.default
 ) extends Command {
@@ -48,8 +46,6 @@ final case class PantsExportCommand(
       save <-
         save
           .copy(
-            lint = lint,
-            cache = cache,
             lintCommand = save.lintCommand.copy(
               app = app
                 .withEnv(app.env.withWorkingDirectory(workingDirectory))

--- a/multiversion/src/main/scala/multiversion/commands/PantsExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/PantsExportCommand.scala
@@ -28,6 +28,7 @@ final case class PantsExportCommand(
     pantsTargets: List[String] = List("3rdparty/jvm::"),
     cwd: Option[Path] = None,
     lint: Boolean = false,
+    cache: Option[Path] = None,
     @Inline
     save: ExportCommand = ExportCommand.default
 ) extends Command {
@@ -48,6 +49,7 @@ final case class PantsExportCommand(
         save
           .copy(
             lint = lint,
+            cache = cache,
             lintCommand = save.lintCommand.copy(
               app = app
                 .withEnv(app.env.withWorkingDirectory(workingDirectory))


### PR DESCRIPTION
`--cache=$HOME/.cache/coursier` can now override the cache directory.
Ref https://get-coursier.io/docs/cache for the current default