### PR TITLE
Consider dependencies and exclusions in evictions

### DIFF
--- a/multiversion/src/main/scala/multiversion/resolvers/ContextualDependency.scala
+++ b/multiversion/src/main/scala/multiversion/resolvers/ContextualDependency.scala
@@ -1,0 +1,10 @@
+package multiversion.resolvers
+
+import coursier.core.Dependency
+import multiversion.configs.ModuleConfig
+
+final case class ContextualDependency(
+    dependency: Dependency,
+    exclusions: Set[ModuleConfig],
+    dependencies: List[String]
+)

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -261,4 +261,44 @@ class ExportCommandSuite extends tests.BaseSuite {
                     |@maven//:org.slf4j_slf4j-api_1.7.12
                     |""".stripMargin
   )
+
+  checkDeps(
+    "dependencies are taken into account during eviction",
+    s"""|  - dependency: org.apiguardian:apiguardian-api:1.1.0
+        |    targets:
+        |      - mytargets:apiguardian-old
+        |    dependencies:
+        |      - mytargets:guava
+        |  - dependency: org.apiguardian:apiguardian-api:1.1.1
+        |    targets:
+        |      - mytargets:apiguardian-new
+        |  - dependency: com.google.guava:guava:25.1-jre
+        |    targets:
+        |      - mytargets:guava
+        |""".stripMargin,
+    queryArgs = allScalaImportDeps("@maven//:org.apiguardian_apiguardian-api_1.1.0"),
+    expectedQuery = """
+                    |@maven//:com.google.code.findbugs_jsr305_3.0.2
+                    |@maven//:com.google.errorprone_error_prone_annotations_2.1.3
+                    |@maven//:com.google.guava_guava_25.1-jre
+                    |@maven//:com.google.j2objc_j2objc-annotations_1.1
+                    |@maven//:org.apiguardian_apiguardian-api_1.1.0
+                    |@maven//:org.checkerframework_checker-qual_2.0.0
+                    |@maven//:org.codehaus.mojo_animal-sniffer-annotations_1.14
+                    |""".stripMargin
+  )
+
+  checkDeps(
+    "exclusions are not forgotten during eviction",
+    s"""|  - dependency: io.cucumber:datatable:3.4.0
+        |    exclusions:
+        |      - organization: org.apiguardian
+        |        name: apiguardian-api
+        |  - dependency: io.cucumber:datatable:3.5.0
+        |""".stripMargin,
+    queryArgs = allScalaImportDeps("@maven//:io.cucumber_datatable_3.4.0"),
+    expectedQuery = """
+                    |@maven//:io.cucumber_datatable_3.4.0
+                    |""".stripMargin
+  )
 }


### PR DESCRIPTION
We cannot reconciliate different versions of an artifact if these
versions were resolved in different context (ie. dependencies and
exclusions), because the targets or other artifact that depend on them
will have different expectations of the resolved graph.