### PR TITLE
Infer and de-duplicate transformation rules

### DIFF
--- a/multiversion/src/main/scala/multiversion/configs/ThirdpartyConfig.scala
+++ b/multiversion/src/main/scala/multiversion/configs/ThirdpartyConfig.scala
@@ -195,6 +195,7 @@ final case class ThirdpartyConfig(
       }
     )
   }
+  lazy val transformations: Result[List[Transformation]] = Transformation.inferTransformations(this)
 }
 
 object ThirdpartyConfig {

--- a/multiversion/src/main/scala/multiversion/configs/Transformation.scala
+++ b/multiversion/src/main/scala/multiversion/configs/Transformation.scala
@@ -1,0 +1,237 @@
+package multiversion.configs
+
+import scala.collection.mutable.Buffer
+
+import moped.json.ErrorResult
+import moped.json.JsonString
+import moped.json.Result
+import moped.json.ValueResult
+import multiversion.configs.Transformation._
+import multiversion.diagnostics.ConflictingTransformationsDiagnostic
+import multiversion.diagnostics.MultidepsEnrichments.XtensionStrings
+
+/**
+ * A transformation that modifies the dependency resolution graph.
+ *
+ * Every transformation can be either canonical or local. Canonical transformations are
+ * transformations that are defined on canonical definitions, and apply globally to the dependency
+ * graph. All other transformations are local transformations and apply only on the targets where
+ * they're defined. These transformations introduce a fork in the dependency resolution graph.
+ */
+sealed trait Transformation {
+
+  /** The configuration where this transformation was defined */
+  def definedOn: DependencyConfig
+
+  /** Is this transformation a canonical transformation? */
+  def canonical: Boolean = {
+    val org = definedOn.organization.value.replaceAllLiterally(".", "/")
+    definedOn.targets.exists(_.startsWith(s"3rdparty/jvm/$org:"))
+  }
+
+  /**
+   * Does this transformation subsume the given transformation? That is, does this transformation
+   * render the given transformation redundant?
+   *
+   * Only global transformations can subsume other transformations.
+   */
+  def subsumes(t1: Transformation): Boolean =
+    (this, t1) match {
+      case (ex0 @ Exclusion(d0, m0), ex1 @ Exclusion(d1, m1)) =>
+        ex0.canonical && m0 == m1
+
+      case (f0 @ Force(d0, m0, v0), f1 @ Force(d1, m1, v1)) =>
+        f0.canonical && m0 == m1 && v0 == v1
+
+      case (a0 @ Addition(d0, dep0), a1 @ Addition(d1, dep1)) =>
+        a0.canonical &&
+          dep0 == dep1 &&
+          d0.organization.value == d1.organization.value &&
+          d0.name == d1.name
+
+      case _ =>
+        false
+    }
+
+  /** Does this transformation conflict with the given transformation? */
+  def conflictsWith(t1: Transformation): Boolean =
+    (this, t1) match {
+      case (f0 @ Force(d0, m0, v0), f1 @ Force(d1, m1, v1)) =>
+        m0 == m1 && v0 != v1 &&
+          (
+            (f0.canonical && f1.canonical) ||
+              (!f0.canonical && !f1.canonical && d0 == d1)
+          )
+
+      case (a0 @ Addition(d0, dep0), a1 @ Addition(d1, dep1)) =>
+        a0.canonical && a1.canonical &&
+          d0.organization.value == d1.organization.value &&
+          d0.name == d1.name &&
+          d0.version == d1.version &&
+          dep0.organization.value == dep1.organization.value &&
+          dep0.name == dep1.name &&
+          dep0.version != dep1.version
+
+      case _ =>
+        false
+    }
+
+  def show: String
+}
+
+object Transformation {
+
+  /**
+   * A transformation configuring the exclusion of the given module.
+   *
+   * Canonical exclusion transformations  will prevent the given module from being resolved in any
+   * resolution, and will apply to the entirety of the main dependency graph.
+   *
+   * Local exclusion transformations will prevent the given module from being resolved when
+   * resolving the module on which the transformation is defined.
+   *
+   * @param definedOn The dependency on which the transformation is defined.  @param excluded The
+   * module to exclude from resolution.
+   */
+  case class Exclusion(definedOn: DependencyConfig, excluded: ModuleConfig) extends Transformation {
+    override def show: String =
+      if (canonical)
+        s"always exclude ${excluded.repr}"
+      else s"exclude ${excluded.repr} when resolving ${definedOn.targets.commas}"
+  }
+
+  /**
+   * A transformation configuring the addition of a dependency to a given module.
+   *
+   * Canonical addition transformations will modify the dependency graph so that the added
+   * dependency is always resolved when the artifact on which the transformation is defined is
+   * resolved.
+   *
+   * Local addition transformations will add the dependency when the target on which the
+   * transformation is defined is being resolved.
+   *
+   * @param definedOn The dependency on which the transformation is defined.
+   * @param dependency The dependency to add.
+   */
+  case class Addition(definedOn: DependencyConfig, dependency: DependencyConfig)
+      extends Transformation {
+    override def show: String = {
+      val depRepr = s"${dependency.organization.value}:${dependency.name}:${dependency.version}"
+      if (canonical)
+        s"always depend on $depRepr when resolving ${definedOn.organization.value}:${definedOn.name}"
+      else s"depend on $depRepr when resolving ${definedOn.targets.commas}"
+    }
+  }
+
+  /**
+   * A transformation configuring the replacement of a version for another.
+   *
+   * Canonical force transformations apply to the entirety of the main dependency graph and will
+   * force the given module to be resolved with the given version.
+   *
+   * Local force transformations will apply only on the resolution of the module on which they're
+   * defined.
+   *
+   * @param definedOn The dependency on which the transformation is defined.
+   * @param module The module whose version to force.
+   * @param version The forced version.
+   */
+  case class Force(definedOn: DependencyConfig, module: ModuleConfig, version: String)
+      extends Transformation {
+    override def show: String =
+      if (canonical) s"always force version of ${module.repr} to $version"
+      else
+        s"force version of ${module.repr} to $version when resolving ${definedOn.targets.commas}"
+  }
+
+  def inferTransformations(config: ThirdpartyConfig): Result[List[Transformation]] =
+    config.dependencies2
+      .foldLeft(TransformationsBuffer.empty)(_ ++ infer(config, _))
+      .toList
+
+  private def infer(config: ThirdpartyConfig, dep: DependencyConfig): List[Transformation] = {
+    val dependencies = dep.dependencies.flatMap { depSpec =>
+      config.depsByTargets
+        .getOrElse(depSpec, Nil)
+        .map(d => (ModuleConfig(d.organization, JsonString(d.name)), depSpec, d.version))
+    }
+    val additionTransformations = dependencies
+      .flatMap {
+        case (_, depSpec, _) =>
+          config.depsByTargets.getOrElse(depSpec, Nil).flatMap { dependency =>
+            val module = ModuleConfig(dependency.organization.value, dependency.name)
+            if (dep.exclusions.contains(module)) None
+            else Some(Addition(dep, dependency))
+          }
+      }
+    val exclusionTransformations = dep.exclusions
+      .filter { ex => !dependencies.exists { case (m, _, _) => m == ex } }
+      .map { ex => Exclusion(dep, ex) }
+      .toList
+    val forceTransformations = dependencies
+      .filter {
+        case (m, _, _) =>
+          dep.exclusions.exists {
+            case ex if ex.name.value == "*" => m.organization.value == ex.organization.value
+            case ex                         => m == ex
+          }
+      }
+      .map { case (m, _, v) => Force(dep, m, v) }
+    additionTransformations ++ exclusionTransformations ++ forceTransformations
+  }
+
+  private case class TransformationsBuffer(
+      exclusions: Buffer[Exclusion],
+      additions: Buffer[Addition],
+      forces: Buffer[Force]
+  ) {
+    def ++(rs: List[Transformation]): TransformationsBuffer = rs.foldLeft(this)(_ + _)
+    def +(r: Transformation): TransformationsBuffer =
+      r match {
+        case e: Exclusion => exclusions += e; this
+        case a: Addition  => additions += a; this
+        case f: Force     => forces += f; this
+      }
+
+    def toList: Result[List[Transformation]] = {
+      val transformations =
+        cleanTransformations(exclusions) ++ cleanTransformations(forces) ++ cleanTransformations(
+          additions
+        )
+      findConflicts(transformations) match {
+        case Nil       => ValueResult(transformations)
+        case conflicts => ErrorResult(ConflictingTransformationsDiagnostic(conflicts))
+      }
+    }
+
+    @annotation.tailrec
+    private def findConflicts(
+        transformations: List[Transformation],
+        acc: List[(Transformation, Transformation)] = Nil
+    ): List[(Transformation, Transformation)] = {
+      transformations match {
+        case current :: rest =>
+          val conflicts = rest.filter(current.conflictsWith(_)).map((current, _))
+          findConflicts(rest, acc ++ conflicts)
+        case Nil =>
+          acc
+      }
+    }
+
+    private def cleanTransformations[T <: Transformation](transformations: Buffer[T]): List[T] = {
+      val (canonTransformations, localTransformations) = transformations.partition(_.canonical)
+      (canonTransformations ++ localTransformations)
+        .foldLeft(List.empty[T]) {
+          case (acc, transformation) if !acc.exists(_.subsumes(transformation)) =>
+            transformation :: acc
+          case (acc, _) => acc
+        }
+        .reverse
+    }
+  }
+
+  private object TransformationsBuffer {
+    def empty: TransformationsBuffer =
+      TransformationsBuffer(Buffer.empty, Buffer.empty, Buffer.empty)
+  }
+}

--- a/multiversion/src/main/scala/multiversion/diagnostics/ConflictingTransformationsDiagnostic.scala
+++ b/multiversion/src/main/scala/multiversion/diagnostics/ConflictingTransformationsDiagnostic.scala
@@ -1,0 +1,27 @@
+package multiversion.diagnostics
+
+import moped.reporters.Diagnostic
+import moped.reporters.ErrorSeverity
+import multiversion.configs.Transformation
+import multiversion.diagnostics.MultidepsEnrichments.XtensionStrings
+
+case class ConflictingTransformationsDiagnostic(
+    val conflicts: List[(Transformation, Transformation)]
+) extends Diagnostic(ErrorSeverity) {
+  private val grouped: List[(Transformation, List[Transformation])] =
+    conflicts.groupBy(_._1).mapValues(_.map(_._2)).toList
+  private val messages: List[String] = grouped.map {
+    case (transformation, conflicts) =>
+      s"""| - Transformation '${transformation.show}' ${definedOn(transformation)} conflicts with:
+          |${conflicts
+        .map(t => s"     - ${t.show} ${definedOn(t)}")
+        .mkString(System.lineSeparator())}
+          |""".stripMargin
+  }
+  override def message: String =
+    s"""|Conflicting transformations have been found:
+        |${messages.mkString(System.lineSeparator())}
+        |""".stripMargin
+  private def definedOn(t: Transformation): String =
+    s"(defined on ${t.definedOn.targets.commas})"
+}

--- a/tests/src/main/scala/tests/ConfigSyntax.scala
+++ b/tests/src/main/scala/tests/ConfigSyntax.scala
@@ -1,0 +1,100 @@
+package tests
+
+trait ConfigSyntax {
+
+  def deps(dependencies: ConfigNode.Dependency*): String = {
+    val clausesStr = dependencies.map(_.toYaml).mkString(System.lineSeparator())
+    s"""|  dependencies:
+        |$clausesStr
+        |""".stripMargin
+  }
+
+  def dep(str: String): ConfigNode.Dependency =
+    str.split(":").toList match {
+      case org :: name :: version :: Nil => ConfigNode.Dependency(org, name, version, Nil, Nil, Nil)
+      case _                             => throw new IllegalArgumentException(str)
+    }
+}
+
+sealed trait ConfigNode {
+  def toYaml: String
+}
+
+object ConfigNode {
+
+  case class Dependency(
+      organization: String,
+      name: String,
+      version: String,
+      dependencies: List[String],
+      exclusions: List[Exclusion],
+      targets: List[String]
+  ) extends ConfigNode {
+
+    def exclude(exclusion: String): Dependency =
+      copy(exclusions = Exclusion(exclusion) :: exclusions)
+
+    def target(target: String): Dependency =
+      copy(targets = target :: targets)
+
+    def dependency(target: String): Dependency =
+      copy(dependencies = target :: dependencies)
+
+    def canonical: Dependency = {
+      val orgPath = organization.replaceAllLiterally(".", "/")
+      target(s"3rdparty/jvm/$orgPath:$name")
+    }
+
+    def toYaml: String = {
+      val exclusionsStr =
+        if (exclusions.isEmpty) ""
+        else {
+          val clausesStr = exclusions.reverse.map(_.toYaml).mkString(System.lineSeparator())
+          s"""|    exclusions:
+          |$clausesStr
+          |""".stripMargin
+        }
+      val dependenciesStr =
+        if (dependencies.isEmpty) ""
+        else {
+          val clausesStr =
+            dependencies.reverse.map(d => s"      - $d").mkString(System.lineSeparator())
+          s"""|    dependencies:
+          |$clausesStr
+          |""".stripMargin
+        }
+      val targetsStr =
+        if (targets.isEmpty) ""
+        else {
+          val clausesStr = targets.reverse.map(t => s"      - $t").mkString(System.lineSeparator())
+          s"""|    targets:
+          |$clausesStr
+          |""".stripMargin
+        }
+
+      s"""|  - dependency: $organization:$name:$version
+        |$exclusionsStr
+        |$dependenciesStr
+        |$targetsStr
+        |""".stripMargin
+    }
+  }
+
+  case class Exclusion(
+      organization: String,
+      name: String
+  ) extends ConfigNode {
+    override def toYaml: String =
+      s"""|      - organization: $organization
+        |        name: '$name'
+        |""".stripMargin
+  }
+
+  object Exclusion {
+    def apply(str: String): Exclusion =
+      str.split(":").toList match {
+        case org :: name :: Nil => Exclusion(org, name)
+        case _                  => throw new IllegalArgumentException(str)
+      }
+  }
+}

--- a/tests/src/main/scala/tests/SimplifiedTransformations.scala
+++ b/tests/src/main/scala/tests/SimplifiedTransformations.scala
@@ -1,0 +1,31 @@
+package tests
+
+import multiversion.configs.Transformation
+
+sealed trait SimplifiedTransformation {
+  def canonical: Boolean
+  def definedOn: List[String]
+}
+
+object SimplifiedTransformation {
+
+  implicit val ordering: Ordering[SimplifiedTransformation] = Ordering.by(_.toString)
+
+  def convert(transformation: Transformation): SimplifiedTransformation =
+    transformation match {
+      case Transformation.Addition(definedOn, dependency) =>
+        val repr = s"${dependency.organization.value}:${dependency.name}:${dependency.version}"
+        Addition(transformation.canonical, definedOn.targets, repr)
+      case Transformation.Force(definedOn, module, version) =>
+        Force(transformation.canonical, definedOn.targets, module.repr, version)
+      case Transformation.Exclusion(definedOn, removing) =>
+        Exclusion(transformation.canonical, definedOn.targets, removing.repr)
+    }
+}
+
+case class Addition(canonical: Boolean, definedOn: List[String], dependency: String)
+    extends SimplifiedTransformation
+case class Force(canonical: Boolean, definedOn: List[String], module: String, version: String)
+    extends SimplifiedTransformation
+case class Exclusion(canonical: Boolean, definedOn: List[String], module: String)
+    extends SimplifiedTransformation

--- a/tests/src/test/scala/tests/configs/BaseConfigSuite.scala
+++ b/tests/src/test/scala/tests/configs/BaseConfigSuite.scala
@@ -1,0 +1,69 @@
+package tests.configs
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+import moped.json.ErrorResult
+import moped.json.ValueResult
+import moped.reporters.ConsoleReporter
+import moped.reporters.Input
+import multiversion.configs.ThirdpartyConfig
+import munit.TestOptions
+
+abstract class BaseConfigSuite extends munit.FunSuite {
+  private val out = new ByteArrayOutputStream()
+  private val reporter: ConsoleReporter = ConsoleReporter(new PrintStream(out))
+  def parseConfig(
+      name: TestOptions,
+      text: String,
+      onSuccess: ThirdpartyConfig => Unit,
+      onError: String => Unit
+  ): Unit = {
+    out.reset()
+    reporter.reset()
+    ThirdpartyConfig.parseYaml(
+      Input.filename(name.name + ".yaml", text)
+    ) match {
+      case ValueResult(value) => onSuccess(value)
+      case ErrorResult(error) =>
+        reporter.log(error)
+        onError(out.toString())
+    }
+  }
+  def check(
+      name: TestOptions,
+      original: String,
+      expected: ThirdpartyConfig
+  )(implicit loc: munit.Location): Unit = {
+    test(name) {
+      parseConfig(
+        name,
+        original,
+        onSuccess = { obtained => assertEquals(obtained, expected) },
+        onError = { error =>
+          fail(error)
+        }
+      )
+    }
+  }
+
+  def checkError(
+      name: TestOptions,
+      original: String,
+      expected: String
+  )(implicit loc: munit.Location): Unit = {
+    test(name) {
+      parseConfig(
+        name,
+        original,
+        onSuccess = { obtained =>
+          fail(s"expected an error but parsed successfully:\n$obtained")
+        },
+        onError = { obtained =>
+          assertNoDiff(obtained, expected)
+        }
+      )
+    }
+  }
+
+}

--- a/tests/src/test/scala/tests/configs/TransformationsSuite.scala
+++ b/tests/src/test/scala/tests/configs/TransformationsSuite.scala
@@ -1,0 +1,389 @@
+package tests.configs
+
+import moped.json.ErrorResult
+import moped.json.Result
+import multiversion.configs.Transformation
+import multiversion.diagnostics.ConflictingTransformationsDiagnostic
+import munit.TestOptions
+import tests.Addition
+import tests.ConfigSyntax
+import tests.Exclusion
+import tests.Force
+import tests.SimplifiedTransformation
+
+class TransformationsSuite extends BaseConfigSuite with ConfigSyntax {
+
+  def checkTransformations(
+      name: TestOptions,
+      original: String,
+      check: Result[List[Transformation]] => Unit
+  )(implicit
+      loc: munit.Location
+  ): Unit = {
+    test(name) {
+      parseConfig(name, original, cfg => check(cfg.transformations), fail(_))
+    }
+  }
+
+  def expectTransformations(
+      name: TestOptions,
+      original: String,
+      expected: List[SimplifiedTransformation]
+  )(implicit
+      loc: munit.Location
+  ): Unit =
+    checkTransformations(
+      name,
+      original,
+      transformations =>
+        assertEquals(
+          transformations.get.map(SimplifiedTransformation.convert).sorted,
+          expected.sorted
+        )
+    )
+
+  def expectConflicts(
+      name: TestOptions,
+      original: String,
+      expected: List[(SimplifiedTransformation, SimplifiedTransformation)]
+  )(implicit loc: munit.Location): Unit =
+    checkTransformations(
+      name,
+      original,
+      {
+        case ErrorResult(ConflictingTransformationsDiagnostic(conflicts)) =>
+          def sortedTuple[T](tpl: (T, T))(implicit ord: Ordering[T]): (T, T) =
+            tpl match {
+              case (a, b) if ord.lteq(a, b) => tpl
+              case (a, b)                   => (b, a)
+            }
+          val converted = conflicts.map {
+            case (a, b) =>
+              sortedTuple(
+                (SimplifiedTransformation.convert(a), SimplifiedTransformation.convert(b))
+              )
+          }.sorted
+          assertEquals(converted, expected.map(sortedTuple(_)).sorted)
+        case other => fail(s"Unexpected result: $other")
+      }
+    )
+
+  expectTransformations(
+    "removal transformations are inferred",
+    deps(
+      dep("org.scalameta:munit:0.7.13")
+        .exclude("org.checkerframework:checker-qual")
+    ),
+    List(
+      Exclusion(false, Nil, "org.checkerframework:checker-qual")
+    )
+  )
+
+  expectTransformations(
+    "addition transformations are inferred",
+    deps(
+      dep("org.scalameta:munit:0.7.13")
+        .dependency("checker-qual"),
+      dep("org.checkerframework:checker-qual:1.2.3")
+        .target("checker-qual")
+    ),
+    List(
+      Addition(false, Nil, "org.checkerframework:checker-qual:1.2.3")
+    )
+  )
+
+  expectTransformations(
+    "replacement transformations are inferred",
+    deps(
+      dep("org.scalameta:munit:0.7.13")
+        .exclude("org.checkerframework:checker-qual")
+        .dependency("checker-qual"),
+      dep("org.checkerframework:checker-qual:1.2.3")
+        .target("checker-qual")
+    ),
+    List(
+      Force(false, Nil, "org.checkerframework:checker-qual", "1.2.3")
+    )
+  )
+
+  expectTransformations(
+    "transformations defined on a canonical definitions are canonical",
+    deps(
+      dep("org.scalameta:munit:0.7.13").canonical
+        .exclude("org.checkerframework:checker-qual")
+    ),
+    List(
+      Exclusion(true, List("3rdparty/jvm/org/scalameta:munit"), "org.checkerframework:checker-qual")
+    )
+  )
+
+  expectTransformations(
+    "transformations defined on local definitions are local",
+    deps(
+      dep("org.scalameta:munit:0.7.13")
+        .exclude("org.checkerframework:checker-qual")
+        .target("foo/bar:baz")
+    ),
+    List(
+      Exclusion(false, List("foo/bar:baz"), "org.checkerframework:checker-qual")
+    )
+  )
+
+  expectTransformations(
+    "canonical exclusion transformations are de-duplicated",
+    deps(
+      dep("org.scalameta:munit:0.7.13").canonical
+        .exclude("org.checkerframework:checker-qual"),
+      dep("org.apache.thrift:libthrift:0.10.0").canonical
+        .exclude("org.checkerframework:checker-qual")
+    ),
+    List(
+      Exclusion(
+        true,
+        List("3rdparty/jvm/org/apache/thrift:libthrift"),
+        "org.checkerframework:checker-qual"
+      )
+    )
+  )
+
+  expectTransformations(
+    "canonical replacement transformations are de-duplicated",
+    deps(
+      dep("org.scalameta:munit:0.7.13").canonical
+        .exclude("org.checkerframework:checker-qual")
+        .dependency("checker-qual"),
+      dep("org.apache.thrift:libthrift:0.10.0").canonical
+        .exclude("org.checkerframework:checker-qual")
+        .dependency("checker-qual"),
+      dep("org.checkerframework:checker-qual:1.2.3")
+        .target("checker-qual")
+    ),
+    List(
+      Force(
+        true,
+        List("3rdparty/jvm/org/apache/thrift:libthrift"),
+        "org.checkerframework:checker-qual",
+        "1.2.3"
+      )
+    )
+  )
+
+  expectTransformations(
+    "local replace subsumed by canonical replacements are de-duplicated",
+    deps(
+      dep("org.apache.thrift:libthrift:0.10.0")
+        .target("libthrift")
+        .exclude("org.checkerframework:checker-qual")
+        .dependency("checker-qual"),
+      dep("org.scalameta:munit:0.7.13").canonical
+        .exclude("org.checkerframework:checker-qual")
+        .dependency("checker-qual"),
+      dep("org.checkerframework:checker-qual:1.2.3")
+        .target("checker-qual")
+    ),
+    List(
+      Force(
+        true,
+        List("3rdparty/jvm/org/scalameta:munit"),
+        "org.checkerframework:checker-qual",
+        "1.2.3"
+      )
+    )
+  )
+
+  expectTransformations(
+    "local exclusion subsumed by canonical exclusion are de-duplicated",
+    deps(
+      dep("org.apache.thrift:libthrift:0.10.0")
+        .target("libthrift")
+        .exclude("org.checkerframework:checker-qual"),
+      dep("org.scalameta:munit:0.7.13").canonical
+        .exclude("org.checkerframework:checker-qual")
+    ),
+    List(
+      Exclusion(true, List("3rdparty/jvm/org/scalameta:munit"), "org.checkerframework:checker-qual")
+    )
+  )
+
+  expectConflicts(
+    "global replacement transformations for different version are in conflict",
+    deps(
+      dep("org.scalameta:munit:0.7.13").canonical
+        .exclude("org.checkerframework:checker-qual")
+        .dependency("checker-qual"),
+      dep("org.apache.thrift:libthrift:0.10.0").canonical
+        .exclude("org.checkerframework:checker-qual")
+        .dependency("checker-qual-other"),
+      dep("org.checkerframework:checker-qual:1.2.3")
+        .target("checker-qual"),
+      dep("org.checkerframework:checker-qual:4.5.6")
+        .target("checker-qual-other")
+    ),
+    List(
+      (
+        Force(
+          true,
+          List("3rdparty/jvm/org/scalameta:munit"),
+          "org.checkerframework:checker-qual",
+          "1.2.3"
+        ),
+        Force(
+          true,
+          List("3rdparty/jvm/org/apache/thrift:libthrift"),
+          "org.checkerframework:checker-qual",
+          "4.5.6"
+        )
+      )
+    )
+  )
+
+  expectTransformations(
+    "local replacements don't conflict with global replacements",
+    deps(
+      dep("org.scalameta:munit:0.7.13").canonical
+        .exclude("org.checkerframework:checker-qual")
+        .dependency("checker-qual"),
+      dep("org.apache.thrift:libthrift:0.10.0")
+        .target("libthrift")
+        .exclude("org.checkerframework:checker-qual")
+        .dependency("checker-qual-other"),
+      dep("org.checkerframework:checker-qual:1.2.3")
+        .target("checker-qual"),
+      dep("org.checkerframework:checker-qual:4.5.6")
+        .target("checker-qual-other")
+    ),
+    List(
+      Force(
+        true,
+        List("3rdparty/jvm/org/scalameta:munit"),
+        "org.checkerframework:checker-qual",
+        "1.2.3"
+      ),
+      Force(false, List("libthrift"), "org.checkerframework:checker-qual", "4.5.6")
+    )
+  )
+
+  expectConflicts(
+    "local replacements of different versions of the same artifact are in conflict",
+    deps(
+      dep("org.scalameta:munit:0.7.13")
+        .target("munit")
+        .exclude("org.checkerframework:checker-qual")
+        .dependency("checker-qual")
+        .dependency("checker-qual-other"),
+      dep("org.checkerframework:checker-qual:1.2.3")
+        .target("checker-qual"),
+      dep("org.checkerframework:checker-qual:4.5.6")
+        .target("checker-qual-other")
+    ),
+    List(
+      (
+        Force(false, List("munit"), "org.checkerframework:checker-qual", "1.2.3"),
+        Force(false, List("munit"), "org.checkerframework:checker-qual", "4.5.6")
+      )
+    )
+  )
+
+  expectConflicts(
+    "global addition for the same module with different versions are in conflict",
+    deps(
+      dep("org.scalameta:munit:0.7.13").canonical
+        .dependency("checker-qual")
+        .dependency("checker-qual-other"),
+      dep("org.checkerframework:checker-qual:1.2.3")
+        .target("checker-qual"),
+      dep("org.checkerframework:checker-qual:4.5.6")
+        .target("checker-qual-other")
+    ),
+    List(
+      (
+        Addition(
+          true,
+          List("3rdparty/jvm/org/scalameta:munit"),
+          "org.checkerframework:checker-qual:1.2.3"
+        ),
+        Addition(
+          true,
+          List("3rdparty/jvm/org/scalameta:munit"),
+          "org.checkerframework:checker-qual:4.5.6"
+        )
+      )
+    )
+  )
+
+  expectTransformations(
+    "wildcard exclusion and addition in the same organization produce addition, exclusion and force",
+    deps(
+      dep("org.scalameta:munit:0.7.13").canonical
+        .exclude("org.checkerframework:*")
+        .dependency("checker-qual"),
+      dep("org.checkerframework:checker-qual:1.2.3")
+        .target("checker-qual")
+    ),
+    List(
+      Exclusion(true, List("3rdparty/jvm/org/scalameta:munit"), "org.checkerframework:*"),
+      Force(
+        true,
+        List("3rdparty/jvm/org/scalameta:munit"),
+        "org.checkerframework:checker-qual",
+        "1.2.3"
+      ),
+      Addition(
+        true,
+        List("3rdparty/jvm/org/scalameta:munit"),
+        "org.checkerframework:checker-qual:1.2.3"
+      )
+    )
+  )
+
+  expectTransformations(
+    "addition of multi-jar dependency",
+    deps(
+      dep("org.scalameta:munit:0.7.13").canonical
+        .dependency("thrift-and-checker-qual"),
+      dep("org.apache.thrift:libthrift:0.10.0")
+        .target("thrift-and-checker-qual"),
+      dep("org.checkerframework:checker-qual:1.2.3")
+        .target("thrift-and-checker-qual")
+    ),
+    List(
+      Addition(
+        true,
+        List("3rdparty/jvm/org/scalameta:munit"),
+        "org.apache.thrift:libthrift:0.10.0"
+      ),
+      Addition(
+        true,
+        List("3rdparty/jvm/org/scalameta:munit"),
+        "org.checkerframework:checker-qual:1.2.3"
+      )
+    )
+  )
+
+  expectTransformations(
+    "exclusion and addition of multi-jar dependency",
+    deps(
+      dep("org.scalameta:munit:0.7.13").canonical
+        .exclude("org.apache.thrift:libthrift")
+        .dependency("thrift-and-checker-qual"),
+      dep("org.apache.thrift:libthrift:0.10.0")
+        .target("thrift-and-checker-qual"),
+      dep("org.checkerframework:checker-qual:1.2.3")
+        .target("thrift-and-checker-qual")
+    ),
+    List(
+      Addition(
+        true,
+        List("3rdparty/jvm/org/scalameta:munit"),
+        "org.checkerframework:checker-qual:1.2.3"
+      ),
+      Force(
+        true,
+        List("3rdparty/jvm/org/scalameta:munit"),
+        "org.apache.thrift:libthrift",
+        "0.10.0"
+      )
+    )
+  )
+
+}

--- a/tests/src/test/scala/tests/configs/WorkspaceConfigSuite.scala
+++ b/tests/src/test/scala/tests/configs/WorkspaceConfigSuite.scala
@@ -1,72 +1,9 @@
 package tests.configs
 
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
-
-import moped.json.ErrorResult
 import moped.json.JsonString
-import moped.json.ValueResult
-import moped.reporters.ConsoleReporter
-import moped.reporters.Input
 import multiversion.configs._
-import munit.TestOptions
 
-class WorkspaceConfigSuite extends munit.FunSuite {
-  val out = new ByteArrayOutputStream()
-  val reporter: ConsoleReporter = ConsoleReporter(new PrintStream(out))
-  private def parseConfig(
-      name: TestOptions,
-      text: String,
-      onSuccess: ThirdpartyConfig => Unit,
-      onError: String => Unit
-  ): Unit = {
-    out.reset()
-    reporter.reset()
-    ThirdpartyConfig.parseYaml(
-      Input.filename(name.name + ".yaml", text)
-    ) match {
-      case ValueResult(value) => onSuccess(value)
-      case ErrorResult(error) =>
-        reporter.log(error)
-        onError(out.toString())
-    }
-  }
-  def check(
-      name: TestOptions,
-      original: String,
-      expected: ThirdpartyConfig
-  )(implicit loc: munit.Location): Unit = {
-    test(name) {
-      parseConfig(
-        name,
-        original,
-        onSuccess = { obtained => assertEquals(obtained, expected) },
-        onError = { error =>
-          fail(error)
-        }
-      )
-    }
-  }
-
-  def checkError(
-      name: TestOptions,
-      original: String,
-      expected: String
-  )(implicit loc: munit.Location): Unit = {
-    test(name) {
-      parseConfig(
-        name,
-        original,
-        onSuccess = { obtained =>
-          fail(s"expected an error but parsed successfully:\n$obtained")
-        },
-        onError = { obtained =>
-          assertNoDiff(obtained, expected)
-        }
-      )
-    }
-  }
-
+class WorkspaceConfigSuite extends BaseConfigSuite {
   check(
     "basic",
     """|scala: 2.12.12


### PR DESCRIPTION
At the moment, the inferred rules are ignored and never used.

The `exclusion` and `dependencies` of the various third party
dependencies that are defined in the ThirdpartyConfig can be seen as
defining global and local transformations of the dependency graph. There
are 3 kinds of transformations that are defined:

 - Addition: This transformation adds a dependency from one module to
   another module. It is created by adding a `dependency` without a
   matching exclusion. When the dependency is resolved, the added
   dependencies will be resolved together.
 - Removal: This transformations excludes prevents a given dependency
   from being resolved. It is created by adding an `exclusion` clause
   that has no matching `dependency`.
 - Replacement: This transformation forces a specific version of a
   dependency. It is created by adding a `dependency` with a matching
   `exclusion`.

All these rules can be understood as either global or local. Global
rules are defined on canonical definitions (the definitions whose target
package matches the organization name). All other rules are local.
Global rules apply to all dependency resolutions, whereas local rules
apply only to the targets where they're defined and will introduce a
fork in the dependency resolution graph.