### PR TITLE
Respect force, and prioritize direct dependencies

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
@@ -46,7 +46,7 @@ import multiversion.resolvers.Sha256
 @CommandName("export")
 case class ExportCommand(
     lint: Boolean = true,
-    outputPath: Path = Paths.get("3rdparty", "jvm_deps.bzl"),
+    outputPath: Path = Paths.get("/tmp", "jvm_deps.bzl"),
     cache: Option[Path] = None,
     @Inline
     lintCommand: LintCommand = LintCommand()
@@ -234,7 +234,9 @@ case class ExportCommand(
           val out =
             if (outputPath.isAbsolute()) outputPath
             else app.env.workingDirectory.resolve(outputPath)
-          Files.createDirectories(out.getParent())
+          if (!Files.exists(out.getParent())) {
+            Files.createDirectories(out.getParent())
+          }
           Files.write(out, rendered.getBytes(StandardCharsets.UTF_8))
           ValueResult(out)
         }

--- a/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
@@ -245,8 +245,9 @@ case class ExportCommand(
 
   def lintPostResolution(index: ResolutionIndex): Result[Unit] = {
     val errors = for {
-      (module, deps) <- index.allDependencies.toList
-      allVersions = deps.map(d => index.reconciledVersion(d))
+      (module, deps0) <- index.allDependencies.toList
+      deps = deps0.map(_._1)
+      allVersions = deps.map { d => index.reconciledVersion(d) }
       if allVersions.size > 1
       diagnostic <- index.thirdparty.depsByModule.get(module) match {
         case Some(declaredDeps) =>

--- a/tests/src/main/scala/tests/BaseSuite.scala
+++ b/tests/src/main/scala/tests/BaseSuite.scala
@@ -81,6 +81,10 @@ abstract class BaseSuite extends MopedSuite(MultiVersion.app) {
   val allGenrules: List[String] = List("kind(genrule, @maven//:all)")
   def allScalaImportDeps(target: String): List[String] =
     List(s"kind(scala_import, allpaths($target, @maven//:all))")
+
+  def exportCommand: List[String] =
+    List("export", "--output-path", "3rdparty/jvm_deps.bzl")
+
   def checkDeps(
       name: TestOptions,
       deps: String,
@@ -95,7 +99,7 @@ abstract class BaseSuite extends MopedSuite(MultiVersion.app) {
   ): Unit = {
     test(name) {
       checkCommand(
-        arguments = List("export"),
+        arguments = exportCommand,
         expectedExit = expectedExit,
         expectedOutput = expectedOutput,
         workingDirectoryLayout = s"""|/3rdparty.yaml

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -5,6 +5,20 @@ class ExportCommandSuite extends tests.BaseSuite {
   checkDeps(
     "evicted artifacts do not create genrules",
     s"""|  - dependency: org.slf4j:slf4j-log4j12:1.6.1
+        |    force: true
+        |  - dependency: org.slf4j:slf4j-log4j12:1.6.4
+        |    force: false
+        |""".stripMargin,
+    queryArgs = allGenrules,
+    expectedQuery = """|@maven//:genrules/log4j_log4j_1.2.16
+                       |@maven//:genrules/org.slf4j_slf4j-api_1.6.1
+                       |@maven//:genrules/org.slf4j_slf4j-log4j12_1.6.1
+                       |""".stripMargin
+  )
+
+  checkDeps(
+    "evicted artifacts do not create genrules",
+    s"""|  - dependency: org.slf4j:slf4j-log4j12:1.6.1
         |  - dependency: org.slf4j:slf4j-log4j12:1.6.4
         |""".stripMargin,
     queryArgs = allGenrules,

--- a/tests/src/test/scala/tests/commands/LintCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/LintCommandSuite.scala
@@ -5,7 +5,7 @@ import tests.BaseSuite
 class LintCommandSuite extends BaseSuite {
   test("basic") {
     checkCommand(
-      arguments = List("export"),
+      arguments = exportCommand,
       expectedOutput = """|✔ Generated '/workingDirectory/3rdparty/jvm_deps.bzl'
                           |""".stripMargin,
       workingDirectoryLayout = s"""|/3rdparty.yaml
@@ -25,7 +25,7 @@ class LintCommandSuite extends BaseSuite {
 
   test("classifier") {
     checkCommand(
-      arguments = List("export"),
+      arguments = exportCommand,
       expectedOutput = """|✔ Generated '/workingDirectory/3rdparty/jvm_deps.bzl'
                           |""".stripMargin,
       workingDirectoryLayout = s"""|/3rdparty.yaml

--- a/tests/src/test/scala/tests/commands/ResolutionTest.scala
+++ b/tests/src/test/scala/tests/commands/ResolutionTest.scala
@@ -52,7 +52,7 @@ class ResolutionTest extends tests.BaseSuite {
 
   test("resolveVersions with and force = True and False") {
     val vs = ResolutionIndex.resolveVersions(
-      Set("2.11.2" -> false, "2.6.7.1" -> true, "2.11.2" -> false),
+      Set("2.11.2" -> false, "2.6.7.1" -> true, "2.11.3" -> false),
       VersionCompatibility.EarlySemVer
     )
     assertEquals(vs.head, "2.6.7.1")

--- a/tests/src/test/scala/tests/commands/ResolutionTest.scala
+++ b/tests/src/test/scala/tests/commands/ResolutionTest.scala
@@ -37,15 +37,38 @@ class ResolutionTest extends tests.BaseSuite {
 
   test("resolveVersions") {
     val vs = ResolutionIndex.resolveVersions(
-      Set("2.11.2", "2.6.7.1", "2.9.9", "2.10.0", "2.10.2", "2.8.4"),
+      Set(
+        "2.11.2" -> true,
+        "2.6.7.1" -> true,
+        "2.9.9" -> true,
+        "2.10.0" -> true,
+        "2.10.2" -> true,
+        "2.8.4" -> true
+      ),
       VersionCompatibility.EarlySemVer
     )
     assertEquals(vs.head, "2.11.2")
   }
 
-  def jodaTime(v: String): Dependency =
+  test("resolveVersions with and force = True and False") {
+    val vs = ResolutionIndex.resolveVersions(
+      Set("2.11.2" -> false, "2.6.7.1" -> true, "2.11.2" -> false),
+      VersionCompatibility.EarlySemVer
+    )
+    assertEquals(vs.head, "2.6.7.1")
+  }
+
+  test("resolveVersions with force = False") {
+    val vs = ResolutionIndex.resolveVersions(
+      Set("2.11.2" -> false, "2.6.7.1" -> false),
+      VersionCompatibility.EarlySemVer
+    )
+    assertEquals(vs.head, "2.11.2")
+  }
+
+  def jodaTime(v: String): (Dependency, Boolean) =
     Dependency(
       Module(Organization("joda-time"), ModuleName("joda-time"), Map.empty),
       v
-    )
+    ) -> true
 }


### PR DESCRIPTION
This assumes all direct dependencies to carry `force=True` similar to Pants, allowing local overrides of certain libraries.
Note this could result to a downgrade of binary compatible transitives, and thus potential runtime errors.