### PR TITLE
Apply global transformations when resolving

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
@@ -16,6 +16,7 @@ import coursier.cache.CacheDefaults
 import coursier.cache.CachePolicy
 import coursier.cache.FileCache
 import coursier.core.Dependency
+import coursier.core.Module
 import coursier.core.Version
 import coursier.util.Artifact
 import coursier.util.Task
@@ -32,12 +33,15 @@ import moped.progressbars.ProgressRenderer
 import moped.reporters.Diagnostic
 import moped.reporters.Input
 import moped.reporters.NoPosition
+import multiversion.configs.DependencyConfig
 import multiversion.configs.ThirdpartyConfig
 import multiversion.configs.Transformation
+import multiversion.configs.VersionsConfig
 import multiversion.diagnostics.ConflictingTransitiveDependencyDiagnostic
 import multiversion.diagnostics.MultidepsEnrichments._
 import multiversion.loggers._
 import multiversion.outputs.ArtifactOutput
+import multiversion.outputs.DependencyResolution
 import multiversion.outputs.DepsOutput
 import multiversion.outputs.Docs
 import multiversion.outputs.ResolutionIndex
@@ -78,8 +82,9 @@ case class ExportCommand(
         .withPool(threads.downloadPool)
         .withChecksums(Nil)
       for {
-        // transformations <- thirdparty.transformations.map(reportTransformations)
-        index <- resolveDependencies(thirdparty, coursierCache)
+        transformations <- thirdparty.transformations
+        resolutions <- initialResolutions(thirdparty, transformations, coursierCache)
+        index <- resolutionsWithAdditions(thirdparty, resolutions, transformations, coursierCache)
         _ <- {
           if (lint) lintPostResolution(index)
           else ValueResult(())
@@ -122,26 +127,86 @@ case class ExportCommand(
     VersionCompatibility.Strict -> "strict"
   )
 
-  private def resolveDependencies(
+  /**
+   * The first resolution step, done by resolving all the dependencies that were defined and taking
+   * into account only the global exclusion and force transformations.
+   *
+   * This first resolution step is necessary in order to determine what are the artifacts that are
+   * resolved in every case. Once we have the list of artifacts pulled in by every resolution, we
+   * can use this information to apply the global addition transformations and run the second
+   * resolution step.
+   *
+   * @param thirdparty The 3rdparty dependency configurations.
+   * @param transformations The transformations to apply to the dependency graph.
+   * @param cache The coursier cache.
+   * @return The dependency resolution for every third party dependency.
+   */
+  private def initialResolutions(
       thirdparty: ThirdpartyConfig,
+      transformations: List[Transformation],
+      cache: FileCache[Task]
+  ): Result[List[DependencyResolution]] = {
+    val exclusions = Transformation.globalExclusions(transformations).map(_.excluded)
+    val forceVersions = toForceVersions(Transformation.globalForces(transformations))
+    val deps = thirdparty.coursierDeps.map { case (dep, cdep) => (dep, cdep, Nil) }
+    runResolutions(thirdparty, deps, exclusions, forceVersions, cache)
+  }
+
+  /**
+   * The second resolution step, which takes into account all the global transformations.
+   *
+   * The global addition transformations are applied on the resolutions until a fixed point is
+   * reached.
+   *
+   * @param thirdparty The 3rdparty dependency configurations.
+   * @param previousResolutions The resolutions done in the previous step.
+   * @param transformations The transformation to apply to the dependency graph.
+   * @param cache The coursier cache.
+   * @return The resolution index after all the addition transformations have been applied.
+   */
+  private def resolutionsWithAdditions(
+      thirdparty: ThirdpartyConfig,
+      previousResolutions: List[DependencyResolution],
+      transformations: List[Transformation],
       cache: FileCache[Task]
   ): Result[ResolutionIndex] = {
-    val deps = thirdparty.coursierDeps
-    val progressBar = new ResolveProgressRenderer(
-      deps.length,
-      app.env.clock,
-      isTesting = app.isTesting
-    )
-    val resolveResults = deps.map {
+    val exclusions = Transformation.globalExclusions(transformations).map(_.excluded)
+    val forceVersions = toForceVersions(Transformation.globalForces(transformations))
+    val additionTransformations =
+      Transformation
+        .globalAdditions(transformations)
+        .groupBy(_.definedOn.coursierModule(thirdparty.scala))
+    val depToResolutions = previousResolutions.groupBy(_.dep)
+    val depToAdditions = thirdparty.coursierDeps.map {
       case (dep, cdep) =>
-        thirdparty.toResolve(dep, cache, progressBar, cdep)
+        val resolutions = depToResolutions.getOrElse(dep, Nil)
+        val additions =
+          unappliedAdditions(dep, resolutions, additionTransformations, thirdparty.scala)
+        (dep, cdep, additions)
     }
-    for {
-      resolves <- Result.fromResults(resolveResults)
-      resolutions <- Result.fromResults(
-        runParallelTasks(resolves, progressBar, cache.ec)
+    val (withAdditions, withoutAdditions) = depToAdditions.partition(_._3.nonEmpty)
+
+    if (withAdditions.isEmpty) {
+      val index = ResolutionIndex.fromResolutions(thirdparty, previousResolutions)
+      Result.value(index)
+    } else {
+      app.err.println(
+        Docs.infoMessage(
+          s"${withAdditions.length} resolutions are affected by additions (${withoutAdditions.length} unchanged); re-resolving."
+        )
       )
-    } yield ResolutionIndex.fromResolutions(thirdparty, resolutions)
+
+      val unchangedResolutions = withoutAdditions.flatMap {
+        case (dep, _, _) => depToResolutions.getOrElse(dep, Nil)
+      }
+
+      for {
+        newResolutions <-
+          runResolutions(thirdparty, withAdditions, exclusions, forceVersions, cache)
+        allResolutions = newResolutions ++ unchangedResolutions
+        index <- resolutionsWithAdditions(thirdparty, allResolutions, transformations, cache)
+      } yield index
+    }
   }
 
   // This also downloads SHA files
@@ -361,14 +426,108 @@ case class ExportCommand(
         case ((add, exc, frc), _: Transformation.Exclusion) => (add, exc + 1, frc)
         case ((add, exc, frc), _: Transformation.Force)     => (add, exc, frc + 1)
       }
+
     val (canon, local) = transformations.partition(_.canonical)
     val (canonAdd, canonExc, canonFrc) = count(canon)
     val (localAdd, localExc, localFrc) = count(local)
+
     val msg =
       s"Inferred ${canon.length} canonical transformations ($canonAdd additions, $canonExc exclusions, $canonFrc forces) and ${local.length} local transformations ($localAdd, $localExc, $localFrc)."
     app.err.println(Docs.successMessage(msg))
     transformations
   }
+
+  /**
+   * The dependencies that should be added to the resolution of `dep`, given the `transformations`.
+   *
+   * @param dep The dependency whose additions to gather.
+   * @param resolutions The previous resolutions of `dep`.
+   * @param transformations The addition transformations to consider.
+   * @return The list of dependencies that should be added to the resolution of `dep`.
+   */
+  private def applicableAdditions(
+      dep: DependencyConfig,
+      resolutions: List[DependencyResolution],
+      transformations: Map[Module, List[Transformation.Addition]]
+  ): List[DependencyConfig] = {
+    for {
+      DependencyResolution(_, res) <- resolutions
+      dependency <- res.dependencies
+      module = dependency.module
+      addition <- transformations.getOrElse(module, Nil)
+    } yield addition.dependency
+  }
+
+  /**
+   * The dependencies that have not yet been added to the resolution of `dep`, but should be.
+   *
+   * @param dep The dependency whose additions to gather.
+   * @param resolutions The previous resolutions of `dep`.
+   * @param transformations The addition transformations to consider.
+   * @param scala The Scala configuration
+   * @return The dependencies that haven't been added to `dep` previously and should be added.
+   */
+  private def unappliedAdditions(
+      dep: DependencyConfig,
+      resolutions: List[DependencyResolution],
+      transformations: Map[Module, List[Transformation.Addition]],
+      scala: VersionsConfig
+  ): List[DependencyConfig] = {
+    val toAdd = applicableAdditions(dep, resolutions, transformations)
+    val toAddReprs = for {
+      depConfig <- toAdd
+      dep <- depConfig.coursierDependencies(scala)
+    } yield dep.repr
+
+    val resolvedRootModulesReprs = for {
+      resolution <- resolutions
+      rootDependency <- resolution.res.rootDependencies
+    } yield rootDependency.repr
+
+    val isAffectedByAdditions = toAddReprs.diff(resolvedRootModulesReprs).nonEmpty
+
+    if (isAffectedByAdditions) toAdd
+    else Nil
+  }
+
+  private def runResolutions(
+      thirdparty: ThirdpartyConfig,
+      dependencies: List[(DependencyConfig, Dependency, List[DependencyConfig])],
+      exclusions: List[Module],
+      forceVersions: List[(Module, String)],
+      cache: FileCache[Task]
+  ): Result[List[DependencyResolution]] = {
+    val progressBar = new ResolveProgressRenderer(
+      dependencies.length,
+      app.env.clock,
+      isTesting = app.isTesting
+    )
+
+    val toResolve = for {
+      (dep, cdep, additions) <- dependencies
+      rootAdditions = additions.flatMap(thirdparty.rootDependencies)
+    } yield thirdparty.toResolve(
+      dep,
+      rootAdditions,
+      exclusions,
+      forceVersions,
+      cache,
+      progressBar,
+      cdep
+    )
+
+    for {
+      resolves <- Result.fromResults(toResolve)
+      resolutions <- Result.fromResults(
+        runParallelTasks(resolves, progressBar, cache.ec)
+      )
+    } yield resolutions
+  }
+
+  private def toForceVersions(transformations: List[Transformation.Force]): List[(Module, String)] =
+    transformations.map {
+      case Transformation.Force(_, module, version) => module -> version
+    }
 
 }
 

--- a/multiversion/src/main/scala/multiversion/outputs/Docs.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/Docs.scala
@@ -33,12 +33,16 @@ object Docs {
   object emoji {
     val success: Doc = colors.green + Doc.text("✔ ") + colors.reset
     val error: Doc = Doc.text("❗")
+    val info: Doc = colors.yellow + Doc.text("ℹ ") + colors.reset
   }
   def successMessage(message: String): String =
     (emoji.success + Doc.text(message)).render(1000)
+  def infoMessage(message: String): String =
+    (emoji.info + Doc.text(message)).render(1000)
   object colors {
     val bold: Doc = Doc.zeroWidth(Console.BOLD)
     val green: Doc = Doc.zeroWidth(Console.GREEN)
+    val yellow: Doc = Doc.zeroWidth(Console.YELLOW)
     val reset: Doc = Doc.zeroWidth(Console.RESET)
   }
 }

--- a/tests/src/main/scala/tests/BaseSuite.scala
+++ b/tests/src/main/scala/tests/BaseSuite.scala
@@ -75,6 +75,16 @@ abstract class BaseSuite extends MopedSuite(MultiVersion.app) {
     }
   }
 
+  def outputMessages(infoSteps: (Int, Int)*): String = {
+    val msgs = infoSteps.map {
+      case (affected, unchanged) =>
+        s"ℹ $affected resolutions are affected by additions ($unchanged unchanged); re-resolving."
+    }
+    s"""|${msgs.mkString(System.lineSeparator())}
+        |✔ Generated '/workingDirectory/3rdparty/jvm_deps.bzl'
+        |""".stripMargin
+  }
+
   val allScalaImports: List[String] = List("kind(scala_import, @maven//:all)")
   val allScalaImportsGraph: List[String] =
     List("kind(scala_import, @maven//:all)", "--output", "graph")
@@ -88,8 +98,7 @@ abstract class BaseSuite extends MopedSuite(MultiVersion.app) {
       queryArgs: List[String] = Nil,
       expectedQuery: String = "",
       expectedExit: Int = 0,
-      expectedOutput: String = """|✔ Generated '/workingDirectory/3rdparty/jvm_deps.bzl'
-           |""".stripMargin
+      expectedOutput: String = outputMessages()
   )(implicit
       loc: munit.Location
   ): Unit = {

--- a/tests/src/main/scala/tests/ConfigSyntax.scala
+++ b/tests/src/main/scala/tests/ConfigSyntax.scala
@@ -3,10 +3,7 @@ package tests
 trait ConfigSyntax {
 
   def deps(dependencies: ConfigNode.Dependency*): String = {
-    val clausesStr = dependencies.map(_.toYaml).mkString(System.lineSeparator())
-    s"""|  dependencies:
-        |$clausesStr
-        |""".stripMargin
+    dependencies.map(_.toYaml).mkString(System.lineSeparator())
   }
 
   def dep(str: String): ConfigNode.Dependency =

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -1,6 +1,6 @@
 package tests.commands
 
-class ExportCommandSuite extends tests.BaseSuite {
+class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
 
   checkDeps(
     "evicted artifacts do not create genrules",
@@ -259,6 +259,64 @@ class ExportCommandSuite extends tests.BaseSuite {
                     |@maven//:org.apiguardian_apiguardian-api_1.1.1
                     |@maven//:org.codehaus.mojo_animal-sniffer-annotations_1.14
                     |@maven//:org.slf4j_slf4j-api_1.7.12
+                    |""".stripMargin
+  )
+
+  checkDeps(
+    "global exclusions are respected",
+    deps(
+      dep("org.apache.thrift:libthrift:0.10.0").canonical
+        .exclude("org.checkerframework:checker-qual"),
+      dep("com.google.guava:guava:25.1-jre")
+    ),
+    queryArgs = allScalaImportDeps("@maven//:com.google.guava_guava_25.1-jre"),
+    expectedQuery = """
+                  |@maven//:com.google.code.findbugs_jsr305_3.0.2
+                  |@maven//:com.google.errorprone_error_prone_annotations_2.1.3
+                  |@maven//:com.google.guava_guava_25.1-jre
+                  |@maven//:com.google.j2objc_j2objc-annotations_1.1
+                  |@maven//:org.codehaus.mojo_animal-sniffer-annotations_1.14
+                  |""".stripMargin
+  )
+
+  checkDeps(
+    "global replacements are respected",
+    deps(
+      dep("org.apache.thrift:libthrift:0.10.0").canonical
+        .exclude("org.checkerframework:checker-qual")
+        .dependency("checker-qual-201"),
+      dep("org.checkerframework:checker-qual:2.0.1")
+        .target("checker-qual-201"),
+      dep("com.google.guava:guava:25.1-jre")
+    ),
+    queryArgs = allScalaImportDeps("@maven//:com.google.guava_guava_25.1-jre"),
+    expectedQuery = """
+                  |@maven//:com.google.code.findbugs_jsr305_3.0.2
+                  |@maven//:com.google.errorprone_error_prone_annotations_2.1.3
+                  |@maven//:com.google.guava_guava_25.1-jre
+                  |@maven//:com.google.j2objc_j2objc-annotations_1.1
+                  |@maven//:org.checkerframework_checker-qual_2.0.1
+                  |@maven//:org.codehaus.mojo_animal-sniffer-annotations_1.14
+                  |""".stripMargin
+  )
+
+  checkDeps(
+    "global additions are respected",
+    deps(
+      dep("org.apiguardian:apiguardian-api:1.1.1").target("apiguardian"),
+      dep("org.checkerframework:checker-qual:2.0.0").canonical.dependency("apiguardian"),
+      dep("com.google.guava:guava:25.1-jre")
+    ),
+    expectedOutput = outputMessages((1, 2)),
+    queryArgs = allScalaImportDeps("@maven//:com.google.guava_guava_25.1-jre"),
+    expectedQuery = """
+                    |@maven//:com.google.code.findbugs_jsr305_3.0.2
+                    |@maven//:com.google.errorprone_error_prone_annotations_2.1.3
+                    |@maven//:com.google.guava_guava_25.1-jre
+                    |@maven//:com.google.j2objc_j2objc-annotations_1.1
+                    |@maven//:org.apiguardian_apiguardian-api_1.1.1
+                    |@maven//:org.checkerframework_checker-qual_2.0.0
+                    |@maven//:org.codehaus.mojo_animal-sniffer-annotations_1.14
                     |""".stripMargin
   )
 }

--- a/tests/src/test/scala/tests/configs/TransformationsSuite.scala
+++ b/tests/src/test/scala/tests/configs/TransformationsSuite.scala
@@ -21,7 +21,9 @@ class TransformationsSuite extends BaseConfigSuite with ConfigSyntax {
       loc: munit.Location
   ): Unit = {
     test(name) {
-      parseConfig(name, original, cfg => check(cfg.transformations), fail(_))
+      val fullConfig = s"""dependencies:
+                          |$original""".stripMargin
+      parseConfig(name, fullConfig, cfg => check(cfg.transformations), fail(_))
     }
   }
 


### PR DESCRIPTION
The global transformations are applied in two steps. First, all
dependencies are resolved while observing only the replacement and
exclusion transformations. Using the resolution results, we can deduce
what global addition transformations apply to every resolution. The
addition transformations are applied until a fixed point is reached.