### PR TITLE
Use single thread for calling coursier resolve

### DIFF
--- a/multiversion/src/main/scala/multiversion/resolvers/CoursierThreadPools.scala
+++ b/multiversion/src/main/scala/multiversion/resolvers/CoursierThreadPools.scala
@@ -12,7 +12,7 @@ class CoursierThreadPools {
 
   // From https://github.com/johnynek/bazel-deps/blob/dbd90f155e45e0b2529999d0b74ea65b49e6fb07/src/scala/com/github/johnynek/bazel_deps/CoursierResolver.scala#L19
   val downloadPool: ExecutorService = Executors.newFixedThreadPool(
-    12,
+    1,
     new ThreadFactory {
       val defaultThreadFactory = Executors.defaultThreadFactory()
       def newThread(r: Runnable) = {


### PR DESCRIPTION
### Problem

When calling courier resolve in parallel, the resolves of coursier may dead lock on its cache

### Solution 

Serialize calling coursier resolve. Note: each coursier resolve can still have its own parallelism.