### PR TITLE
Revert "Use single thread for calling coursier resolve"

### DIFF
--- a/multiversion/src/main/scala/multiversion/resolvers/CoursierThreadPools.scala
+++ b/multiversion/src/main/scala/multiversion/resolvers/CoursierThreadPools.scala
@@ -12,7 +12,7 @@ class CoursierThreadPools {
 
   // From https://github.com/johnynek/bazel-deps/blob/dbd90f155e45e0b2529999d0b74ea65b49e6fb07/src/scala/com/github/johnynek/bazel_deps/CoursierResolver.scala#L19
   val downloadPool: ExecutorService = Executors.newFixedThreadPool(
-    1,
+    12,
     new ThreadFactory {
       val defaultThreadFactory = Executors.defaultThreadFactory()
       def newThread(r: Runnable) = {


### PR DESCRIPTION
This reverts commit b2e27c88c037735359b769bed1c82fa0c61a5b46.

As it turns out there was no dead lock, but infinite loop due to a bad pom.