### PR TITLE
Apply global exclusions only to matching modules

### DIFF
--- a/multiversion/src/main/scala/multiversion/configs/Changed.scala
+++ b/multiversion/src/main/scala/multiversion/configs/Changed.scala
@@ -1,0 +1,14 @@
+package multiversion.configs
+
+sealed trait Changes[T] extends Any {
+  def value: T
+  def changed: Boolean
+}
+object Changes {
+  case class Changed[T](value: T) extends AnyVal with Changes[T] {
+    override def changed: Boolean = true
+  }
+  case class Unchanged[T](value: T) extends AnyVal with Changes[T] {
+    override def changed: Boolean = false
+  }
+}

--- a/multiversion/src/main/scala/multiversion/configs/ResolutionConfig.scala
+++ b/multiversion/src/main/scala/multiversion/configs/ResolutionConfig.scala
@@ -1,0 +1,11 @@
+package multiversion.configs
+
+import coursier.core.Dependency
+import coursier.core.Module
+
+case class ResolutionConfig(
+    dependency: DependencyConfig,
+    coursierDep: Dependency,
+    exclusions: List[Module],
+    additions: List[DependencyConfig]
+)

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -276,21 +276,52 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
                     |""".stripMargin
   )
 
-  checkDeps(
+  checkMultipleDeps(
     "global exclusions are respected",
     deps(
-      dep("org.apache.thrift:libthrift:0.10.0").canonical
+      dep("com.google.guava:guava:27.1-jre").canonical
         .exclude("org.checkerframework:checker-qual"),
-      dep("com.google.guava:guava:25.1-jre")
+      dep("org.apache.pulsar:pulsar-client:2.4.2").canonical,
+      dep("com.google.inject:guice:4.2.3").canonical
     ),
-    queryArgs = allScalaImportDeps("@maven//:com.google.guava_guava_25.1-jre"),
-    expectedQuery = """
-                  |@maven//:com.google.code.findbugs_jsr305_3.0.2
-                  |@maven//:com.google.errorprone_error_prone_annotations_2.1.3
-                  |@maven//:com.google.guava_guava_25.1-jre
-                  |@maven//:com.google.j2objc_j2objc-annotations_1.1
-                  |@maven//:org.codehaus.mojo_animal-sniffer-annotations_1.14
-                  |""".stripMargin
+    expectedOutput = outputMessages((1, 2)),
+    queries = List(
+      allScalaImportDeps("@maven//:com.google.guava_guava_27.1-jre") ->
+        """|@maven//:com.google.code.findbugs_jsr305_3.0.2
+           |@maven//:com.google.errorprone_error_prone_annotations_2.2.0
+           |@maven//:com.google.guava_failureaccess_1.0.1
+           |@maven//:com.google.guava_guava_27.1-jre
+           |@maven//:com.google.guava_listenablefuture_9999.0-empty-to-avoid-conflict-with-guava
+           |@maven//:com.google.j2objc_j2objc-annotations_1.1
+           |@maven//:org.codehaus.mojo_animal-sniffer-annotations_1.17""".stripMargin,
+      allScalaImportDeps("@maven//:org.apache.pulsar_pulsar-client_2.4.2") ->
+        """|@maven//:com.github.luben_zstd-jni_1.3.7-3
+           |@maven//:com.google.code.findbugs_jsr305_3.0.2
+           |@maven//:com.google.errorprone_error_prone_annotations_2.2.0
+           |@maven//:com.google.j2objc_j2objc-annotations_1.1
+           |@maven//:com.sun.activation_javax.activation_1.2.0
+           |@maven//:javax.validation_validation-api_1.1.0.Final
+           |@maven//:org.apache.pulsar_protobuf-shaded_2.1.0-incubating
+           |@maven//:org.apache.pulsar_pulsar-client-api_2.4.2
+           |@maven//:org.apache.pulsar_pulsar-client_2.4.2
+           |@maven//:org.bouncycastle_bcpkix-jdk15on_1.60
+           |@maven//:org.bouncycastle_bcprov-jdk15on_1.60
+           |@maven//:org.checkerframework_checker-qual_2.0.0
+           |@maven//:org.codehaus.mojo_animal-sniffer-annotations_1.17
+           |@maven//:org.lz4_lz4-java_1.5.0
+           |@maven//:org.slf4j_slf4j-api_1.7.25""".stripMargin,
+      allScalaImportDeps("@maven//:com.google.inject_guice_4.2.3") ->
+        """|@maven//:aopalliance_aopalliance_1.0
+           |@maven//:com.google.code.findbugs_jsr305_3.0.2
+           |@maven//:com.google.errorprone_error_prone_annotations_2.2.0
+           |@maven//:com.google.guava_failureaccess_1.0.1
+           |@maven//:com.google.guava_guava_27.1-jre
+           |@maven//:com.google.guava_listenablefuture_9999.0-empty-to-avoid-conflict-with-guava
+           |@maven//:com.google.inject_guice_4.2.3
+           |@maven//:com.google.j2objc_j2objc-annotations_1.1
+           |@maven//:javax.inject_javax.inject_1
+           |@maven//:org.codehaus.mojo_animal-sniffer-annotations_1.17""".stripMargin
+    )
   )
 
   checkDeps(

--- a/tests/src/test/scala/tests/configs/TransformationsSuite.scala
+++ b/tests/src/test/scala/tests/configs/TransformationsSuite.scala
@@ -136,13 +136,14 @@ class TransformationsSuite extends BaseConfigSuite with ConfigSyntax {
     deps(
       dep("org.scalameta:munit:0.7.13").canonical
         .exclude("org.checkerframework:checker-qual"),
-      dep("org.apache.thrift:libthrift:0.10.0").canonical
+      dep("org.scalameta:munit:0.7.12")
+        .target("3rdparty/jvm/org/scalameta:older-munit")
         .exclude("org.checkerframework:checker-qual")
     ),
     List(
       Exclusion(
         true,
-        List("3rdparty/jvm/org/apache/thrift:libthrift"),
+        List("3rdparty/jvm/org/scalameta:munit"),
         "org.checkerframework:checker-qual"
       )
     )
@@ -196,8 +197,8 @@ class TransformationsSuite extends BaseConfigSuite with ConfigSyntax {
   expectTransformations(
     "local exclusion subsumed by canonical exclusion are de-duplicated",
     deps(
-      dep("org.apache.thrift:libthrift:0.10.0")
-        .target("libthrift")
+      dep("org.scalameta:munit:0.7.12")
+        .target("older-munit")
         .exclude("org.checkerframework:checker-qual"),
       dep("org.scalameta:munit:0.7.13").canonical
         .exclude("org.checkerframework:checker-qual")


### PR DESCRIPTION
Previously, global exclusion transformations would prevent excluded
modules from appearing in any resolution's results. Instead, this commit
changes the application of the global exclusion transformations so that they
apply only on the resolutions that include the module on which the
transformation is defined.

For instance, if we consider the following third party configuration:

```
 - com.google.guava:guava:27.1-jre,
     excludes org.checkerframework:checker-qual
     (defining a global exclusion)
 - org.apache.pulsar:pulsar-client:2.4.2,
     depends on org.checkerframework:checker-qual:2.0.0
 - com.google.inject:guice:4.2.4,
     depends on com.google.guava:guava:4.2.3
```

Then, the resolution of guava will not include
`org.checkerframework:checker-qual` (because it is excluded). The
resolution of `com.google.inject:guice` will not include it either,
because `guice` transitively depends on `guava` which excludes
`checker-qual`.  Finally, `pulsar-client` will include the dependency on
`checker-qual`.  Prior to this commit, `pulsar-client` wouldn't include
the dependency on `checker-qual`, because it would be globally excluded.