### PR TITLE
Fix on CLI integer parsing

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
@@ -54,9 +54,9 @@ case class ExportCommand(
     @Inline
     lintCommand: LintCommand = LintCommand(),
     @Description("Retry limit when fetching a file.")
-    retryCount: Int = 2,
+    retryCount: String = "2",
     @Description("Number of parallel resolves and downloads.")
-    parallel: Int = 4,
+    parallel: String = "4",
 ) extends Command {
   def app = lintCommand.app
   def run(): Int = {
@@ -67,7 +67,7 @@ case class ExportCommand(
   }
   def runResult(thirdparty: ThirdpartyConfig): Result[Unit] = {
     withThreadPool[Result[Unit]](
-      parallel,
+      parallel.toInt,
       { threads =>
         val coursierCache: FileCache[Task] = FileCache().noCredentials
           .withCachePolicies(
@@ -85,7 +85,7 @@ case class ExportCommand(
           .withTtl(scala.concurrent.duration.Duration.Inf)
           .withPool(threads.downloadPool)
           .withChecksums(Nil)
-          .withRetry(retryCount)
+          .withRetry(retryCount.toInt)
         for {
           initialResolutions <- runResolutions(thirdparty, thirdparty.coursierDeps, coursierCache)
           initialIndex = ResolutionIndex.fromResolutions(thirdparty, initialResolutions)

--- a/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
@@ -54,9 +54,11 @@ case class ExportCommand(
     @Inline
     lintCommand: LintCommand = LintCommand(),
     @Description("Retry limit when fetching a file.")
-    retryCount: String = "2",
+    @ParseAsNumber
+    retryCount: Int = 2,
     @Description("Number of parallel resolves and downloads.")
-    parallel: String = "4",
+    @ParseAsNumber
+    parallel: Int = 4,
 ) extends Command {
   def app = lintCommand.app
   def run(): Int = {
@@ -67,7 +69,7 @@ case class ExportCommand(
   }
   def runResult(thirdparty: ThirdpartyConfig): Result[Unit] = {
     withThreadPool[Result[Unit]](
-      parallel.toInt,
+      parallel,
       { threads =>
         val coursierCache: FileCache[Task] = FileCache().noCredentials
           .withCachePolicies(
@@ -85,7 +87,7 @@ case class ExportCommand(
           .withTtl(scala.concurrent.duration.Duration.Inf)
           .withPool(threads.downloadPool)
           .withChecksums(Nil)
-          .withRetry(retryCount.toInt)
+          .withRetry(retryCount)
         for {
           initialResolutions <- runResolutions(thirdparty, thirdparty.coursierDeps, coursierCache)
           initialIndex = ResolutionIndex.fromResolutions(thirdparty, initialResolutions)


### PR DESCRIPTION
### Problem

```
$ java -Xmx10g -jar /Users/yic/workspace/multiversion/multiversion/target/scala-2.12/bazel-multiversion-assembly-0.1.0-SNAPSHOT.jar pants-export --output-path a.out --no-lint --cache /tmp/cache 3rdparty/jvm/:: --parallel 2
error: Type mismatch at '.parallel.save';
  found    : String
  expected : Int
```