### PR TITLE
Empty resolutions still create targets

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
@@ -35,7 +35,7 @@ case class LintCommand(
       query <- runQuery(s"allpaths($expr, @maven//:all)")
       index = new DependenciesIndex(query)
       conflicts = targets.map(findConflicts(_, index))
-      diagnostic = Diagnostic.fromDiagnostics(conflicts.flatten)
+      diagnostic = Diagnostic.fromDiagnostics(conflicts.flatten.sortBy(_.toString))
       result <- diagnostic.map(Result.error).getOrElse(Result.value(()))
     } yield result
   }

--- a/tests/src/main/scala/tests/ConfigSyntax.scala
+++ b/tests/src/main/scala/tests/ConfigSyntax.scala
@@ -9,7 +9,7 @@ trait ConfigSyntax {
   def dep(str: String): ConfigNode.Dependency =
     str.split(":").toList match {
       case org :: name :: version :: Nil =>
-        ConfigNode.Dependency(org, name, version, Nil, Nil, Nil, force = false)
+        ConfigNode.Dependency(org, name, version, None, Nil, Nil, Nil, force = false)
       case _ => throw new IllegalArgumentException(str)
     }
 }
@@ -24,11 +24,15 @@ object ConfigNode {
       organization: String,
       name: String,
       version: String,
+      classifier: Option[String],
       dependencies: List[String],
       exclusions: List[Exclusion],
       targets: List[String],
       force: Boolean
   ) extends ConfigNode {
+
+    def classifier(classifier: String): Dependency =
+      copy(classifier = Option(classifier))
 
     def exclude(exclusion: String): Dependency =
       copy(exclusions = Exclusion(exclusion) :: exclusions)
@@ -70,10 +74,11 @@ object ConfigNode {
         }
 
       s"""|  - dependency: $organization:$name:$version
-        |$exclusionsStr
-        |$dependenciesStr
-        |$targetsStr
-        |""".stripMargin
+          |    classifier: ${classifier.orNull}
+          |$exclusionsStr
+          |$dependenciesStr
+          |$targetsStr
+          |""".stripMargin
     }
   }
 

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -354,4 +354,17 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
            |@maven//:commons-logging/commons-logging/1.2.jar""".stripMargin
     )
   )
+
+  checkMultipleDeps(
+    "Generate target for inexistent classifiers",
+    deps(
+      dep("io.zipkin:zipkin-thrift:1.4.1")
+        .classifier("whatever")
+        .target("with-classifier")
+    ),
+    queries = List(
+      allJars("@maven//:with-classifier") ->
+        "@maven//:org.scala-lang/scala-library/2.11.7.jar"
+    )
+  )
 }

--- a/tests/src/test/scala/tests/commands/LintCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/LintCommandSuite.scala
@@ -137,7 +137,7 @@ class LintCommandSuite extends BaseSuite with ConfigSyntax {
         expectedOutput = defaultExpectedOutput,
         workingDirectoryLayout = workingDirectoryLayout
       )
-      val expectedResult = Diagnostic.fromDiagnostics(expectedErrors) match {
+      val expectedResult = Diagnostic.fromDiagnostics(expectedErrors.sortBy(_.toString)) match {
         case None      => Result.value(())
         case Some(err) => Result.error(err)
       }


### PR DESCRIPTION
Previously, we would not create a target matching the third party root
(ie. `@maven//:3rdparty/jvm/foo_bar`) when the resolution yield only
artifacts that appear to be unrelated to the resolved root dependency.
This situation arises, for instance, when resolving a classifier that
does not exist.

This commit ensures that we still generate the third party root target.
In the test introduced by this commit, the target
`@maven//:with-classifier` wouldn't exist prior to this patch.