### PR TITLE
Use all classifiers to get declared dependencies

### DIFF
--- a/multiversion/src/main/scala/multiversion/configs/ThirdpartyConfig.scala
+++ b/multiversion/src/main/scala/multiversion/configs/ThirdpartyConfig.scala
@@ -57,7 +57,7 @@ final case class ThirdpartyConfig(
   }
 
   val declaredDependencies: Set[DependencyId] =
-    dependencies.map(_.toId).toSet
+    dependencies2.map(_.toId).toSet
   val depsByModule: Map[Module, List[DependencyConfig]] =
     dependencies2.groupBy(_.coursierModule(scala))
   val depsByTargets: Map[String, List[DependencyConfig]] = {

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -131,6 +131,27 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
   )
 
   checkDeps(
+    "classifier with eviction 2",
+    s"""|  - dependency: org.apache.kafka:kafka-clients:2.5.0
+        |    versionScheme: pvp
+        |    targets: [client-2.5.0]
+        |  - dependency: org.apache.kafka:kafka-clients:2.4.0
+        |    versionScheme: pvp
+        |    classifier: test
+        |    targets: [client-2.4.0]
+        |""".stripMargin,
+    queryArgs = allScalaImportDeps("@maven//:client-2.4.0"),
+    expectedQuery = """|@maven//:_com.github.luben_zstd-jni_1.4.4-7
+                       |@maven//:_org.lz4_lz4-java_1.7.1
+                       |@maven//:_org.slf4j_slf4j-api_1.7.30
+                       |@maven//:_org.xerial.snappy_snappy-java_1.1.7.3
+                       |@maven//:client-2.4.0
+                       |@maven//:org.apache.kafka_kafka-clients_2.4.0_658677426
+                       |@maven//:org.apache.kafka_kafka-clients_2.4.0_test_658677426
+                       |""".stripMargin
+  )
+
+  checkDeps(
     "kafka-streams",
     s"""|  - dependency: org.apache.kafka:kafka-streams:2.4.1
         |    versionScheme: pvp


### PR DESCRIPTION
Previously, we could be missing some declared dependencies when versions
with classifiers were evicted.