### PR TITLE
Report all resolved dependencies

### DIFF
--- a/multiversion/src/main/scala/multiversion/loggers/ResolveProgressRenderer.scala
+++ b/multiversion/src/main/scala/multiversion/loggers/ResolveProgressRenderer.scala
@@ -20,10 +20,13 @@ class ResolveProgressRenderer(
   private lazy val timer = new Timer(clock)
   override def renderStop(): Doc = {
     if (isTesting) Doc.empty
-    else
+    else {
+      // Force loggers to report
+      loggers.getActiveLoggers()
       Docs.emoji.success + Doc.text(
         s"Resolved ${loggers.totalRootDependencies} root dependencies and ${loggers.totalTransitiveDependencies} transitive dependencies in ${timer.format()}"
       )
+    }
   }
   override def renderStep(): ProgressStep = {
     val activeLoggers =


### PR DESCRIPTION
Previously, a race condition in the progress reporter could produce
unstable output when reporting the number of resolved dependencies. By
forcing all loggers to report the number of resolved dependencies, we
can ensure that we get the total number of resolved dependencies.