### PR TITLE
Fix shape of the graph

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
@@ -152,7 +152,7 @@ case class ExportCommand(
           val dep = originalDependency.toCoursierDependency(thirdparty.scala)
           val reconciledVersion = index.reconciledVersion(dep)
           val reconciledDependency = originalDependency.copy(version = reconciledVersion)
-          val reconciledId = reconciledDependency.toId
+          val reconciledId = reconciledDependency.id
           // Different dependencies may reconcile to the same version. In this case, make sure
           // we don't lose the targets they originate from.
           deps.get(reconciledId) match {

--- a/multiversion/src/main/scala/multiversion/configs/DependencyConfig.scala
+++ b/multiversion/src/main/scala/multiversion/configs/DependencyConfig.scala
@@ -43,13 +43,17 @@ final case class DependencyConfig(
     transitive: Boolean = true
 ) {
 
-  def toId: DependencyId =
+  val id: DependencyId =
     DependencyId(
       organization.value,
       name,
       version,
-      classifier
+      classifier,
+      dependencies,
+      exclusions
     )
+
+  val suffix: String = "_" + id.##
 
   def toCoursierDependency(scalaVersion: VersionsConfig): Dependency =
     Dependency(

--- a/multiversion/src/main/scala/multiversion/configs/ThirdpartyConfig.scala
+++ b/multiversion/src/main/scala/multiversion/configs/ThirdpartyConfig.scala
@@ -36,7 +36,7 @@ final case class ThirdpartyConfig(
 ) {
   val dependencies2: List[DependencyConfig] = {
     // populate classifiers to all versions to make them eviction proof
-    def fillIn(p: (Module, Vector[DependencyConfig])): Vector[DependencyConfig] = {
+    def fillIn(p: (DependencyId, Vector[DependencyConfig])): Vector[DependencyConfig] = {
       val xs = p._2
       val versions = xs.map(_.version).distinct
       val classifiers = xs.map(_.classifier).distinct
@@ -51,13 +51,11 @@ final case class ThirdpartyConfig(
       }
     }
     dependencies.toVector
-      .groupBy(_.coursierModule(scala))
+      .groupBy(_.id)
       .flatMap(fillIn)
       .toList
   }
 
-  val declaredDependencies: Set[DependencyId] =
-    dependencies2.map(_.toId).toSet
   val depsByModule: Map[Module, List[DependencyConfig]] =
     dependencies2.groupBy(_.coursierModule(scala))
   val depsByTargets: Map[String, List[DependencyConfig]] = {

--- a/multiversion/src/main/scala/multiversion/diagnostics/MultidepsEnrichments.scala
+++ b/multiversion/src/main/scala/multiversion/diagnostics/MultidepsEnrichments.scala
@@ -14,7 +14,6 @@ import moped.json.Result
 import moped.json.ValueResult
 import moped.reporters.Diagnostic
 import moped.reporters.Reporter
-import multiversion.resolvers.DependencyId
 
 object MultidepsEnrichments {
   implicit class XtensionString(string: String) {
@@ -80,15 +79,6 @@ object MultidepsEnrichments {
 
       s"@maven//:${org}/${moduleName}/${version}${classifierOrConfigRepr}.jar"
     }
-
-    def toDependencyId: DependencyId =
-      DependencyId(
-        dep.module.organization.value,
-        dep.module.name.value,
-        dep.version,
-        if (isEmptyLikeConfiguration(dep.configuration)) None
-        else Some(dep.configuration.value)
-      )
 
     def withoutConfig: Dependency =
       dep.withConfiguration(Configuration.empty)

--- a/multiversion/src/main/scala/multiversion/resolvers/DependencyId.scala
+++ b/multiversion/src/main/scala/multiversion/resolvers/DependencyId.scala
@@ -1,8 +1,27 @@
 package multiversion.resolvers
 
+import multiversion.configs.ModuleConfig
+
 final case class DependencyId(
     organization: String,
     name: String,
     version: String,
-    classifier: Option[String]
+    classifier: Option[String],
+    dependencies: List[String],
+    excludes: List[String]
 )
+
+object DependencyId {
+  def apply(
+      organization: String,
+      name: String,
+      version: String,
+      classifier: Option[String],
+      dependencies: List[String],
+      excludes: Set[ModuleConfig]
+  ): DependencyId = {
+    val sortedDependencies = dependencies.distinct.sorted
+    val sortedExcludes = excludes.toList.map(_.repr).distinct.sorted
+    new DependencyId(organization, name, version, classifier, sortedDependencies, sortedExcludes)
+  }
+}


### PR DESCRIPTION
Previously, the dependency graph produced by multiversion did not follow
the shape that we expected it to have. The graph was considering only a
single `DependencyConfig` for every `ArtifactOutput`, even though there
are situation where the same artifact may be pulled in via different
`DependencyConfig`s.