### PR TITLE
Separate task parallelism and download parallelism

### DIFF
--- a/multiversion/src/main/scala/multiversion/resolvers/CoursierThreadPools.scala
+++ b/multiversion/src/main/scala/multiversion/resolvers/CoursierThreadPools.scala
@@ -6,21 +6,31 @@ import java.util.concurrent.ThreadFactory
 
 import scala.concurrent.ExecutionContext
 
-class CoursierThreadPools(threadCount: Int) {
+/**
+ * Thread pool used to resolve POM files.
+ *
+ * @param taskParalleism represents the number of parallel resolution tasks
+ * @param downloadParallelism represents the number of parallel downloads
+ */
+class CoursierThreadPools(taskParalleism: Int, downloadParallelism: Int) {
 
-  def close(): Unit = downloadPool.shutdownNow()
+  def close(): Unit = {
+    downloadPool.shutdownNow()
+    taskPool.shutdownNow()
+  }
+
+  private val threadFactory: ThreadFactory = new ThreadFactory {
+    val defaultThreadFactory = Executors.defaultThreadFactory()
+    def newThread(r: Runnable) = {
+      val t = defaultThreadFactory.newThread(r)
+      t.setDaemon(true)
+      t
+    }
+  }
 
   // From https://github.com/johnynek/bazel-deps/blob/dbd90f155e45e0b2529999d0b74ea65b49e6fb07/src/scala/com/github/johnynek/bazel_deps/CoursierResolver.scala#L19
-  val downloadPool: ExecutorService = Executors.newFixedThreadPool(
-    threadCount,
-    new ThreadFactory {
-      val defaultThreadFactory = Executors.defaultThreadFactory()
-      def newThread(r: Runnable) = {
-        val t = defaultThreadFactory.newThread(r)
-        t.setDaemon(true)
-        t
-      }
-    }
-  )
-  val ec: ExecutionContext = ExecutionContext.fromExecutorService(downloadPool)
+  val downloadPool: ExecutorService =
+    Executors.newFixedThreadPool(downloadParallelism, threadFactory)
+  val taskPool: ExecutorService = Executors.newFixedThreadPool(downloadParallelism, threadFactory)
+  val ec: ExecutionContext = ExecutionContext.fromExecutorService(taskPool)
 }


### PR DESCRIPTION
Add --parallel-download option.
This separates task parallelism (number of parallel resolve) and
download parallelism (number of parallel download by Coursier).