### PR TITLE
Return exit code 100 for lint errors

### DIFF
--- a/multiversion/src/main/scala/multiversion/diagnostics/MultidepsEnrichments.scala
+++ b/multiversion/src/main/scala/multiversion/diagnostics/MultidepsEnrichments.scala
@@ -31,6 +31,19 @@ object MultidepsEnrichments {
   implicit class XtensionApplication(app: Application) {
     def isTesting: Boolean =
       app.env.isSettingTrue("MULTIDEPS_TESTING")
+
+    def completeEither(result: Result[Either[Diagnostic, Unit]]): Int =
+      result match {
+        case ValueResult(Right(())) =>
+          app.reporter.exitCode()
+        case ValueResult(Left(diagnostic)) =>
+          app.reporter.log(diagnostic)
+          100
+        case ErrorResult(error) =>
+          app.reporter.log(error)
+          1
+      }
+
     def complete(result: Result[Unit]): Int =
       result match {
         case ValueResult(()) =>


### PR DESCRIPTION
Problem
-------
Currently both build errors and lint errors return 1, which is
indistinguishable during stats collecting.

Solution
--------
We'll return 100 for lint errors.