### PR TITLE
Workaround semver compat bug

### DIFF
--- a/multiversion/src/main/scala/multiversion/outputs/ResolutionIndex.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/ResolutionIndex.scala
@@ -235,7 +235,7 @@ object ResolutionIndex {
   def isCompat(version1: String, version2: String, compat: VersionCompatibility): Boolean = {
     val min1 = minimumVersion(version1, compat)
     val min2 = minimumVersion(version2, compat)
-    (min1 == min2) || (min1 + ".0" == min2) || (min1 == min2 + ".0")
+    (min1 == min2) || (min1 + ".0" == min2) || (min1 == min2 + ".0") || (min1 + ".0.0" == min2) || (min1 == min2 + ".0.0")
   }
 
   def minimumVersion(v0: String, compat: VersionCompatibility): String = {

--- a/tests/src/test/scala/tests/commands/ResolutionTest.scala
+++ b/tests/src/test/scala/tests/commands/ResolutionTest.scala
@@ -66,6 +66,11 @@ class ResolutionTest extends tests.BaseSuite {
     assertEquals(vs.head, "2.11.2")
   }
 
+  test("semver compat") {
+    assert(ResolutionIndex.isCompat("2.0.0", "2.4.3", VersionCompatibility.EarlySemVer))
+    assert(ResolutionIndex.isCompat("2.0.0", "2.4.3", VersionCompatibility.SemVerSpec))
+  }
+
   def jodaTime(v: String): (Dependency, Boolean) =
     Dependency(
       Module(Organization("joda-time"), ModuleName("joda-time"), Map.empty),


### PR DESCRIPTION
There's a bug in coursier versions where the `minimumCompatibleVersion`
of a version ending in zero doesn't match what we would expect, causing
versions such as 2.0.0 and 2.4.3 to be considered as incompatible under
semver.

See https://github.com/coursier/versions/pull/11