### PR TITLE
Don't follow rootDependencies to gather roots

### DIFF
--- a/multiversion/src/main/scala/multiversion/outputs/ResolutionIndex.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/ResolutionIndex.scala
@@ -159,7 +159,7 @@ object ResolutionIndex {
     } {
       val rootsBuffer =
         roots.getOrElseUpdate(dependency, mutable.LinkedHashSet.empty)
-      rootsBuffer ++= resolution.res.rootDependencies
+      rootsBuffer += resolution.dep.toCoursierDependency(thirdparty.scala)
     }
     ResolutionIndex(
       thirdparty,

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -69,7 +69,10 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
   checkDeps(
     "basic",
     """|  - dependency: com.google.guava:guava:29.0-jre
+       |  - dependency: org.apiguardian:apiguardian-api:1.1.1
+       |    targets: [apiguardian]
        |  - dependency: org.eclipse.lsp4j:org.eclipse.lsp4j:0.9.0
+       |    dependencies: [apiguardian]
        |""".stripMargin,
     expectedOutput = """|/workingDirectory/3rdparty.yaml:3:16 error: transitive dependency 'com.google.guava:guava' has conflicting versions.
          |       found versions: 27.1-jre


### PR DESCRIPTION
Because inter-target dependencies will be passed to coursier as multiple
root dependencies, using a resolution's `rootDependencies` to get the
resolution roots may yield unexpected results. As a result, unrelated
targets may show in the result of `export --lint`.

Instead, we gather the resolution roots from the third party
configuration.