### PR TITLE
Add support for round-trip dependencies

### DIFF
--- a/multiversion/src/main/scala/multiversion/configs/ModuleConfig.scala
+++ b/multiversion/src/main/scala/multiversion/configs/ModuleConfig.scala
@@ -23,6 +23,8 @@ final case class ModuleConfig(
 object ModuleConfig {
   def apply(organization: String, moduleName: String): ModuleConfig =
     ModuleConfig(JsonString(organization), JsonString(moduleName))
+  def apply(module: Module): ModuleConfig =
+    ModuleConfig(module.organization.value, module.name.value)
   val default: ModuleConfig = ModuleConfig()
   implicit val codec: JsonCodec[ModuleConfig] =
     moped.macros.deriveCodec(default)

--- a/multiversion/src/main/scala/multiversion/configs/OverrideTargetConfig.scala
+++ b/multiversion/src/main/scala/multiversion/configs/OverrideTargetConfig.scala
@@ -1,12 +1,34 @@
 package multiversion.configs
 
+import coursier.core.Module
+import coursier.core.ModuleName
+import coursier.core.Organization
 import moped.json.JsonCodec
+import moped.macros.ClassShaper
 final case class OverrideTargetConfig(
-    from: String = "",
+    from: Module = Module(Organization(""), ModuleName(""), Map.empty),
     to: String = ""
 )
 
 object OverrideTargetConfig {
+  private implicit val moduleCodec: JsonCodec[Module] = JsonCodec
+    .encoderDecoderJsonCodec[String](ClassShaper.empty, implicitly, implicitly)
+    .bimap(
+      _.repr,
+      toModule
+    )
+
+  private def toModule(str: String): Module = {
+    val colon = str.indexOf(':')
+    if (colon >= 0) {
+      val org = Organization(str.substring(0, colon))
+      val name = ModuleName(str.substring(colon + 1))
+      Module(org, name, Map.empty)
+    } else {
+      throw new IllegalArgumentException(s"Not a module: '$str'")
+    }
+  }
+
   val default: OverrideTargetConfig = OverrideTargetConfig()
   implicit val codec: JsonCodec[OverrideTargetConfig] =
     moped.macros.deriveCodec(default)

--- a/multiversion/src/main/scala/multiversion/configs/ThirdpartyConfig.scala
+++ b/multiversion/src/main/scala/multiversion/configs/ThirdpartyConfig.scala
@@ -35,6 +35,13 @@ final case class ThirdpartyConfig(
     dependencies: List[DependencyConfig] = List(),
     scala: VersionsConfig = VersionsConfig()
 ) {
+  val overrideTargetsMap: Map[Module, List[String]] =
+    overrideTargets
+      .groupBy(_.from)
+      .mapValues(_.map(_.to))
+      .toMap
+  val overriddingTargets: Set[String] =
+    overrideTargets.map(_.to).toSet
   val dependencies2: List[DependencyConfig] = {
     // populate classifiers to all versions to make them eviction proof
     def fillIn(p: (DependencyId, Vector[DependencyConfig])): Vector[DependencyConfig] = {

--- a/multiversion/src/main/scala/multiversion/outputs/ArtifactOutput.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/ArtifactOutput.scala
@@ -87,12 +87,19 @@ object ArtifactOutput {
         outputs.map(o => (o.mavenLabel, "_" + o.label)).unzip
       }
 
+    val overriddingTargets = for {
+      config <- targetConfigs
+      dependency <- config.dependencies
+      if index.thirdparty.overriddingTargets.contains(dependency)
+    } yield dependency
+
+    val allLabels = (overriddingTargets ++ depLabels).distinct
     TargetOutput(
       kind = "scala_import",
       "name" -> Docs.literal(name),
       "jars" -> Docs.array(jars: _*),
-      "deps" -> Docs.array(depLabels: _*),
-      "exports" -> Docs.array(depLabels: _*),
+      "deps" -> Docs.array(allLabels: _*),
+      "exports" -> Docs.array(allLabels: _*),
       "visibility" -> Docs.array("//visibility:public")
     ).toDoc
   }

--- a/tests/src/main/scala/tests/ConfigSyntax.scala
+++ b/tests/src/main/scala/tests/ConfigSyntax.scala
@@ -6,12 +6,24 @@ trait ConfigSyntax {
     dependencies.map(_.toYaml).mkString(System.lineSeparator())
   }
 
+  def overrideTargets(overrides: (String, String)*): String = {
+    s"""|
+        |overrideTargets:
+        |${overrides.map(overrideYaml).mkString(System.lineSeparator())}
+        |""".stripMargin
+  }
+
   def dep(str: String): ConfigNode.Dependency =
     str.split(":").toList match {
       case org :: name :: version :: Nil =>
         ConfigNode.Dependency(org, name, version, None, Nil, Nil, Nil, force = false)
       case _ => throw new IllegalArgumentException(str)
     }
+
+  private def overrideYaml(or: (String, String)): String =
+    s"""|  - from: '${or._1}'
+        |    to: '${or._2}'
+        |""".stripMargin
 }
 
 sealed trait ConfigNode {

--- a/tests/src/test/scala/tests/commands/LintCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/LintCommandSuite.scala
@@ -29,7 +29,7 @@ class LintCommandSuite extends BaseSuite with ConfigSyntax {
                                    |  - dependency: org.eclipse.lsp4j:org.eclipse.lsp4j:0.9.0
                                    |    dependencies:
                                    |      - guava27
-                                   |$bazelWorkspace
+                                   |${bazelWorkspace("")}
                                    |""".stripMargin
     )
   }
@@ -60,7 +60,7 @@ class LintCommandSuite extends BaseSuite with ConfigSyntax {
                                    |    "@maven//:kafka-test-2.4.1",
                                    |  ],
                                    |)
-                                   |$bazelWorkspace
+                                   |${bazelWorkspace("")}
                                    |""".stripMargin,
       lintArgs = List("lint", "//foo:foo"),
     )
@@ -135,7 +135,7 @@ class LintCommandSuite extends BaseSuite with ConfigSyntax {
                                      |scala: 2.12.1403772
                                      |dependencies:
                                      |$deps
-                                     |$bazelWorkspace
+                                     |${bazelWorkspace("")}
                                      |/foo/BUILD
                                      |load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
                                      |


### PR DESCRIPTION
Round-trip dependencies are dependencies that are published, but also
exist as source in the repository. Because these are published, they can
appear as dependencies of other resolved artifacts. However, these
artifacts shouldn't be resolved and a dependency should be added on the
source target instead.

This commit implements support for round-trip dependencies by leveraging
the `overriddeTargets` attribute in the input export. This attribute
contains a list of mapping from modules to the source target that they
should replace.

After the first resolution, the resolution configuration that depend on
one overridden dependencies are re-configured so that these dependencies
are excluded, and the source dependency is added instead.