### PR TITLE
Report intra-target version conflicts

### DIFF
--- a/multiversion/src/main/scala/multiversion/diagnostics/IntraTargetConflictDiagnostic.scala
+++ b/multiversion/src/main/scala/multiversion/diagnostics/IntraTargetConflictDiagnostic.scala
@@ -1,0 +1,21 @@
+package multiversion.diagnostics
+
+import coursier.core.Module
+import moped.reporters.Diagnostic
+import moped.reporters.ErrorSeverity
+import moped.reporters.Position
+import multiversion.diagnostics.MultidepsEnrichments._
+
+class IntraTargetConflictDiagnostic(
+    val target: String,
+    val module: Module,
+    val foundVersions: List[String],
+    pos: Position
+) extends Diagnostic(ErrorSeverity, "", pos) {
+  require(foundVersions.nonEmpty)
+  override def message: String = {
+    s"""|Within '$target', the module '${module.repr}' is resolved multiple times with incompatible versions ${foundVersions.commas}.
+        |To fix this problem, update your dependencies to compatible versions, or add exclusion rules to force compatible versions of '${module.repr}'.
+        |""".stripMargin
+  }
+}

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -521,4 +521,21 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
            |@maven//:org.slf4j/slf4j-api/1.7.12.jar""".stripMargin,
     )
   )
+
+  checkMultipleDeps(
+    "intra-target conflict",
+    deps(
+      dep("com.google.auto:auto-common:1.0")
+        .target("broken-target"),
+      dep("com.google.inject:guice:4.0")
+        .target("broken-target")
+    ),
+    expectedExit = 1,
+    expectedOutput =
+      """|/workingDirectory/3rdparty.yaml:11:16 error: Within 'broken-target', the module 'com.google.guava:guava' is resolved multiple times with incompatible versions 16.0.1, 30.1.1-jre.
+         |To fix this problem, update your dependencies to compatible versions, or add exclusion rules to force compatible versions of 'com.google.guava:guava'.
+         |
+         |  - dependency: com.google.inject:guice:4.0
+         |                ^""".stripMargin
+  )
 }


### PR DESCRIPTION
When a target owns multiple third party dependencies, and these third
party dependencies (or their transitive dependencies) have conflicting
versions, we now report an error (even when `--lint`ing is off).