### PR TITLE
Avoid missing targets in generated graph

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
@@ -252,7 +252,6 @@ case class ExportCommand(
             List(Try {
               val output = ArtifactOutput(
                 dependency = r.dependency,
-                config = r.config,
                 artifact = r.artifact,
                 artifactSha256 = Sha256.compute(file)
               )

--- a/multiversion/src/main/scala/multiversion/outputs/ResolutionIndex.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/ResolutionIndex.scala
@@ -127,12 +127,10 @@ final case class ResolutionIndex(
   private lazy val owningConfigs: collection.Map[String, collection.Set[DependencyConfig]] = {
     val res = mutable.LinkedHashMap.empty[String, mutable.Set[DependencyConfig]]
     resolutions.foreach { r =>
-      val transitive0 = r.res.dependencyArtifacts().map(_._1).distinct.toSeq
-      val transitive = transitive0.map { actualDependency(_, r.res.projectCache) }
-      transitive.foreach { dep =>
-        val buffer = res.getOrElseUpdate(dep.bazelLabel, mutable.LinkedHashSet.empty)
-        buffer += r.dep
-      }
+      val dep = r.dep.toCoursierDependency(thirdparty.scala)
+      val reconciled = reconciledDependency(dep)
+      val buffer = res.getOrElseUpdate(reconciled.bazelLabel, mutable.LinkedHashSet.empty)
+      buffer += r.dep
     }
     res
   }


### PR DESCRIPTION
Previously, the generated third party dependency graph was sometimes
missing some of the targets representing the transitive resolution of a
dependency.

The faulty logic that decided whether such a target needs to be emitted
relied on matching the resolved artifact with the resolution that pulled
the artifact in (they had to have matching organization, name and
version). This is flawed, because we have no guarantee that the artifact
that is eventually selected will necessarily be coming from the
resolution of that module in particular.

This logic is rewritten to rely solely on the resolution index, which is
now correctly populated with the reconciled versions.