### PR TITLE
resolve command

### DIFF
--- a/multiversion/src/main/scala/multiversion/MultiVersion.scala
+++ b/multiversion/src/main/scala/multiversion/MultiVersion.scala
@@ -17,6 +17,7 @@ object MultiVersion {
       CommandParser[ExportCommand],
       CommandParser[PantsExportCommand],
       CommandParser[LintCommand],
+      CommandParser[ResolveCommand],
       CommandParser[JarsCommand],
       CommandParser[CompletionsCommand]
     )

--- a/multiversion/src/main/scala/multiversion/commands/ResolveCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/ResolveCommand.scala
@@ -1,0 +1,69 @@
+package multiversion.commands
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import moped.annotations.CommandName
+import moped.annotations.Description
+import moped.annotations.ExampleUsage
+import moped.annotations.PositionalArguments
+import moped.annotations.Repeated
+import moped.cli.Application
+import moped.cli.Command
+import moped.cli.CommandParser
+import moped.json.Result
+import moped.reporters.Diagnostic
+import multiversion.BazelUtil
+import multiversion.diagnostics.MultidepsEnrichments._
+
+@ExampleUsage("multiversion resolve //aaa/bbb:ccc")
+@CommandName("resolve")
+@Description("Query the classpath resolution given a target")
+case class ResolveCommand(
+    @Description("Print dependency tree") tree: Boolean = false,
+    @Description("Print //3rdparty references") `3rdparty`: Boolean = false,
+    @Description("Path to bazel executable") bazel: Path = Paths.get("bazel"),
+    @Repeated @Description("Additional arguments to pass to bazel") bazelArgs: List[String] = Nil,
+    @PositionalArguments targets: List[String] = Nil,
+    app: Application = Application.default
+) extends Command {
+
+  override def run(): Int = app.complete(runResult())
+
+  def runResult(): Result[Unit] =
+    for {
+      r <- runCustomQuery()
+    } yield (if (tree) r else r.sorted).foreach(app.println(_))
+
+  private def resolveQuery(target: String): String =
+    s"""filter("@maven.*", kind("generated file", deps(${target})))"""
+
+  private def resolve3rdpartyQuery(target: String): String =
+    s"""kind("third_party_jvm_import", deps(${target}))"""
+
+  private def allPathQuery(target: String): String =
+    s"""allpaths($target, @maven//:all)"""
+
+  def runCustomQuery(): Result[List[String]] = {
+    val usage = Result.error(Diagnostic.error("resolve command requires 1 target argument"))
+    def runResult0(target: String) =
+      if (`3rdparty`) runQueryStr(resolve3rdpartyQuery(target))
+      else if (tree) runQueryStr(allPathQuery(target))
+      else runQueryStr(resolveQuery(target))
+    if (targets.size != 1) usage
+    else runResult0(targets.head)
+  }
+
+  private def runQueryStr(queryExpression: String): Result[List[String]] = {
+    val extraBazelArgs =
+      if (tree) List("--output", "graph") ::: bazelArgs
+      else bazelArgs
+    BazelUtil.runQueryStr(app, bazel, queryExpression, extraBazelArgs)
+  }
+}
+
+object ResolveCommand {
+  val default: ResolveCommand = ResolveCommand()
+  implicit val parser: CommandParser[ResolveCommand] =
+    CommandParser.derive(default)
+}

--- a/tests/src/test/scala/tests/commands/ResolveCommandTest.scala
+++ b/tests/src/test/scala/tests/commands/ResolveCommandTest.scala
@@ -1,0 +1,160 @@
+package tests.commands
+
+import multiversion.commands.ResolveCommand
+import munit.TestOptions
+import tests.BaseSuite
+import tests.ConfigSyntax
+
+class ResolveCommandTest extends BaseSuite with ConfigSyntax {
+  testJarsResults(
+    "basic",
+    deps(
+      dep("org.reflections:reflections:0.9.11")
+        .target("reflections"),
+      dep("com.google.inject:guice:4.0")
+        .target("guice")
+    ),
+    List("@maven//:reflections", "@maven//:guice"),
+    query = "foo",
+    expectedOutput = expectedOutput1,
+  )
+
+  testJarsResults(
+    "tree",
+    deps(
+      dep("org.reflections:reflections:0.9.11")
+        .target("reflections"),
+      dep("com.google.inject:guice:4.0")
+        .target("guice")
+    ),
+    List("@maven//:reflections", "@maven//:guice"),
+    query = "foo",
+    tree = true,
+    expectedOutput = expectedOutput2,
+  )
+
+  testJarsResults(
+    "3rdparty",
+    deps(
+      dep("org.reflections:reflections:0.9.11")
+        .target("reflections"),
+      dep("com.google.inject:guice:4.0")
+        .target("guice")
+    ),
+    List("@maven//:reflections", "@maven//:guice"),
+    query = "foo",
+    `3rdparty` = true,
+    // this can't be tested since 3rdparty aliases are not created here
+    expectedOutput = Nil,
+  )
+
+  lazy val expectedOutput1: List[String] = List(
+    "@maven//:aopalliance/aopalliance/1.0.jar",
+    "@maven//:com.google.guava/guava/16.0.1.jar",
+    "@maven//:com.google.guava/guava/20.0.jar",
+    "@maven//:com.google.inject/guice/4.0.jar",
+    "@maven//:javax.inject/javax.inject/1.jar",
+    "@maven//:org.javassist/javassist/3.21.0-GA.jar",
+    "@maven//:org.reflections/reflections/0.9.11.jar",
+  )
+
+  lazy val expectedOutput2: List[String] = List(
+    "digraph mygraph {",
+    "  node [shape=box];",
+    "  \"//foo:foo\"",
+    "  \"//foo:foo\" -> \"@maven//:guice\"",
+    "  \"//foo:foo\" -> \"@maven//:reflections\"",
+    "  \"@maven//:reflections\"",
+    "  \"@maven//:reflections\" -> \"@maven//:org.reflections_reflections_0.9.11_132265592\"",
+    "  \"@maven//:reflections\" -> \"@maven//:org.reflections/reflections/0.9.11.jar\"",
+    "  \"@maven//:org.reflections_reflections_0.9.11_132265592\"",
+    "  \"@maven//:org.reflections_reflections_0.9.11_132265592\" -> \"@maven//:_com.google.guava_guava_20.0\"",
+    "  \"@maven//:org.reflections_reflections_0.9.11_132265592\" -> \"@maven//:_org.javassist_javassist_3.21.0-GA\"",
+    "  \"@maven//:org.reflections_reflections_0.9.11_132265592\" -> \"@maven//:org.reflections/reflections/0.9.11.jar\"",
+    "  \"@maven//:org.reflections/reflections/0.9.11.jar\"",
+    "  \"@maven//:org.reflections/reflections/0.9.11.jar\" -> \"@maven//:genrules/org.reflections_reflections_0.9.11\"",
+    "  \"@maven//:genrules/org.reflections_reflections_0.9.11\"",
+    "  \"@maven//:_com.google.guava_guava_20.0\"",
+    "  \"@maven//:_com.google.guava_guava_20.0\" -> \"@maven//:com.google.guava/guava/20.0.jar\"",
+    "  \"@maven//:com.google.guava/guava/20.0.jar\"",
+    "  \"@maven//:com.google.guava/guava/20.0.jar\" -> \"@maven//:genrules/com.google.guava_guava_20.0\"",
+    "  \"@maven//:genrules/com.google.guava_guava_20.0\"",
+    "  \"@maven//:guice\"",
+    "  \"@maven//:guice\" -> \"@maven//:com.google.inject_guice_4.0_-701794567\"",
+    "  \"@maven//:guice\" -> \"@maven//:com.google.inject/guice/4.0.jar\"",
+    "  \"@maven//:com.google.inject_guice_4.0_-701794567\"",
+    "  \"@maven//:com.google.inject_guice_4.0_-701794567\" -> \"@maven//:_aopalliance_aopalliance_1.0\"",
+    "  \"@maven//:com.google.inject_guice_4.0_-701794567\" -> \"@maven//:_com.google.guava_guava_16.0.1\"",
+    "  \"@maven//:com.google.inject_guice_4.0_-701794567\" -> \"@maven//:_javax.inject_javax.inject_1\"",
+    "  \"@maven//:com.google.inject_guice_4.0_-701794567\" -> \"@maven//:com.google.inject/guice/4.0.jar\"",
+    "  \"@maven//:com.google.inject/guice/4.0.jar\"",
+    "  \"@maven//:com.google.inject/guice/4.0.jar\" -> \"@maven//:genrules/com.google.inject_guice_4.0\"",
+    "  \"@maven//:genrules/com.google.inject_guice_4.0\"",
+    "  \"@maven//:_com.google.guava_guava_16.0.1\"",
+    "  \"@maven//:_com.google.guava_guava_16.0.1\" -> \"@maven//:com.google.guava/guava/16.0.1.jar\"",
+    "  \"@maven//:_aopalliance_aopalliance_1.0\"",
+    "  \"@maven//:_aopalliance_aopalliance_1.0\" -> \"@maven//:aopalliance/aopalliance/1.0.jar\"",
+    "  \"@maven//:aopalliance/aopalliance/1.0.jar\"",
+    "  \"@maven//:aopalliance/aopalliance/1.0.jar\" -> \"@maven//:genrules/aopalliance_aopalliance_1.0\"",
+    "  \"@maven//:genrules/aopalliance_aopalliance_1.0\"",
+    "  \"@maven//:_javax.inject_javax.inject_1\"",
+    "  \"@maven//:_javax.inject_javax.inject_1\" -> \"@maven//:javax.inject/javax.inject/1.jar\"",
+    "  \"@maven//:javax.inject/javax.inject/1.jar\"",
+    "  \"@maven//:javax.inject/javax.inject/1.jar\" -> \"@maven//:genrules/javax.inject_javax.inject_1\"",
+    "  \"@maven//:genrules/javax.inject_javax.inject_1\"",
+    "  \"@maven//:_org.javassist_javassist_3.21.0-GA\"",
+    "  \"@maven//:_org.javassist_javassist_3.21.0-GA\" -> \"@maven//:org.javassist/javassist/3.21.0-GA.jar\"",
+    "  \"@maven//:org.javassist/javassist/3.21.0-GA.jar\"",
+    "  \"@maven//:org.javassist/javassist/3.21.0-GA.jar\" -> \"@maven//:genrules/org.javassist_javassist_3.21.0-GA\"",
+    "  \"@maven//:genrules/org.javassist_javassist_3.21.0-GA\"",
+    "  \"@maven//:com.google.guava/guava/16.0.1.jar\"",
+    "  \"@maven//:com.google.guava/guava/16.0.1.jar\" -> \"@maven//:genrules/com.google.guava_guava_16.0.1\"",
+    "  \"@maven//:genrules/com.google.guava_guava_16.0.1\"",
+    "}",
+  )
+
+  private def testJarsResults(
+      name: TestOptions,
+      deps: String,
+      combine: List[String],
+      query: String,
+      tree: Boolean = false,
+      `3rdparty`: Boolean = false,
+      extraBuild: String = "",
+      expectedExitCode: Int = 0,
+      expectedOutput: List[String] = Nil,
+      tags: List[String] = Nil,
+  ): Unit = {
+    val workingDirectoryLayout = s"""|/3rdparty.yaml
+                                     |scala: 2.12.1403772
+                                     |dependencies:
+                                     |$deps
+                                     |${bazelWorkspace("")}
+                                     |/foo/BUILD
+                                     |load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+                                     |
+                                     |scala_library(
+                                     |  name = "foo",
+                                     |  srcs = [],
+                                     |  deps = ${combine.mkString("[\"", "\", \"", "\"]")},
+                                     |  tags = ${tags.mkString("[\"", "\", \"", "\"]")},
+                                     |)
+                                     |$extraBuild""".stripMargin
+    test(name) {
+      checkCommand(
+        arguments = exportCommand ++ List("--no-lint"),
+        expectedExit = 0,
+        expectedOutput = defaultExpectedOutput,
+        workingDirectoryLayout = workingDirectoryLayout
+      )
+      val obtainedResult =
+        ResolveCommand(
+          tree = tree,
+          `3rdparty` = `3rdparty`,
+          targets = List(query),
+          app = app()
+        ).runCustomQuery()
+      assertEquals(obtainedResult.get.sorted, expectedOutput.sorted)
+    }
+  }
+}


### PR DESCRIPTION
This adds a Bazel query wrapper called `resolve`
While debugging the bazel-multiversion resolution, I often want to find
out what JAR files were eventually selected given a library or binary target.

Example
-------
```
multiversion resolve //aaa/bbb
```

This will print out:
```
@maven//:junit/junit/4.12.jar
@maven//:net.bytebuddy/byte-buddy-agent/1.10.5.jar
....
```

In addition there are also `--tree` and `--3rdparty` options,
which prints out dependency graph (like Coursier `--tree`),
and just the 3rdparty/jvm target names respectively.