### PR TITLE
Add option to print yaml logs to Stdout

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
@@ -136,8 +136,11 @@ case class LintCommand(
         }
       }
 
-  def writeToStdout(report: String): Unit =
+  def writeToStdout(report: String): Unit = {
+    app.println("# -------- Begin Lint Result")
     app.println(report)
+    app.println("# -------- End Lint Result")
+  }
 
   def writeToFile(report: String, path: Path): Unit = {
     val pathAbs = if (path.isAbsolute()) {

--- a/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
@@ -33,7 +33,7 @@ case class LintCommand(
     @PositionalArguments queryExpressions: List[String] = Nil,
     app: Application = Application.default
 ) extends Command {
-  val silence = lintReportPath.exists { p => p.toString() == "-" }
+  val silence: Boolean = lintReportPath.exists { p => p.toString() == "-" }
   def run(): Int = app.completeEither(runResult(), silence)
 
   def runResult(): Result[Either[Diagnostic, Unit]] = {
@@ -135,19 +135,19 @@ case class LintCommand(
           writeToFile(rendered, out)
         }
       }
-      
-  def writeToStdout(report: String): Unit = 
+
+  def writeToStdout(report: String): Unit =
     app.println(report)
-      
+
   def writeToFile(report: String, path: Path): Unit = {
     val pathAbs = if (path.isAbsolute()) {
-                  path
-                } else {
-                  app.env.workingDirectory.resolve(path)
-                }
+      path
+    } else {
+      app.env.workingDirectory.resolve(path)
+    }
     Files.createDirectories(pathAbs.getParent())
     Files.write(pathAbs, report.getBytes(StandardCharsets.UTF_8))
-    }
+  }
 }
 
 object LintCommand {

--- a/multiversion/src/main/scala/multiversion/diagnostics/MultidepsEnrichments.scala
+++ b/multiversion/src/main/scala/multiversion/diagnostics/MultidepsEnrichments.scala
@@ -39,7 +39,7 @@ object MultidepsEnrichments {
         case ValueResult(Left(diagnostic)) =>
           if (!silence) {
             app.reporter.log(diagnostic)
-          }  
+          }
           100
         case ErrorResult(error) =>
           if (!silence) {

--- a/multiversion/src/main/scala/multiversion/diagnostics/MultidepsEnrichments.scala
+++ b/multiversion/src/main/scala/multiversion/diagnostics/MultidepsEnrichments.scala
@@ -32,15 +32,19 @@ object MultidepsEnrichments {
     def isTesting: Boolean =
       app.env.isSettingTrue("MULTIDEPS_TESTING")
 
-    def completeEither(result: Result[Either[Diagnostic, Unit]]): Int =
+    def completeEither(result: Result[Either[Diagnostic, Unit]], silence: Boolean = false): Int =
       result match {
         case ValueResult(Right(())) =>
           app.reporter.exitCode()
         case ValueResult(Left(diagnostic)) =>
-          app.reporter.log(diagnostic)
+          if (!silence) {
+            app.reporter.log(diagnostic)
+          }  
           100
         case ErrorResult(error) =>
-          app.reporter.log(error)
+          if (!silence) {
+            app.reporter.log(error)
+          }
           1
       }
 


### PR DESCRIPTION
**Problem**
Multiversion linting error logs need to be parsed and are currently printed to stdout in a human readable format

**Solution**
Update the writeLintReport function to print YAML to stdout if given a '-' as a file path
Update the completeEither function to take an optional 'silence' parameter to silence human readable logs when printing the YAML to stdout