### PR TITLE
Add descriptive keys to YAML report structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ website/yarn.lock
 website/node_modules
 website/i18n/*
 !website/i18n/en.json
+.bsp
 
 project/metals.sbt
 bazel-*

--- a/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/LintCommand.scala
@@ -119,13 +119,23 @@ case class LintCommand(
           case (target, conflicts) =>
             val isFailure = conflicts.exists(!_.isPending)
             val moduleVersions = conflicts
+              .sortBy(_.module.repr)
               .map {
                 case LintDiagnostic(_, module, _, versions, _) =>
-                  module.repr -> Docs.array(versions.sorted: _*)
+                  Docs.obj(
+                    List(
+                      "dependency" -> Docs.literal(module.repr),
+                      "versions" -> Docs.array(versions.sorted: _*)
+                    )
+                  )
               }
-              .sortBy(_._1)
-            Docs.literal(target) + Docs.colon + Doc.space + Docs.obj(
-              List("failure" -> Doc.str(isFailure), "conflicts" -> Docs.obj(moduleVersions))
+            Docs.dash + Doc.space + Docs.obj(
+              List(
+                "target" -> Docs.literal(target),
+                "failure" -> Doc.str(isFailure),
+                "conflicts" -> (Docs.openBracket + Doc
+                  .intercalate(Doc.comma + Doc.space, moduleVersions) + Docs.closeBracket)
+              )
             )
         }
         val rendered = Doc.intercalate(Doc.line, docs).render(Int.MaxValue)

--- a/multiversion/src/main/scala/multiversion/outputs/Docs.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/Docs.scala
@@ -21,6 +21,7 @@ object Docs {
   val openBracket: Doc = Doc.char('[')
   val closeBracket: Doc = Doc.char(']')
   val colon: Doc = Doc.char(':')
+  val dash: Doc = Doc.char('-')
   def obj(entries: Iterable[(String, Doc)]): Doc = {
     val mappings = entries.map {
       case (key, value) =>

--- a/tests/src/test/scala/tests/commands/LintCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/LintCommandSuite.scala
@@ -81,7 +81,7 @@ class LintCommandSuite extends BaseSuite with ConfigSyntax {
     expectedExitCode = 100,
     tags = "dupped_3rdparty" :: Nil,
     expectedReport =
-      """|"//foo:foo": {"failure": false, "conflicts": {"com.google.guava:guava": ["16.0.1", "20.0"]}}""".stripMargin
+      """|- {"target": "//foo:foo", "failure": false, "conflicts": [{"dependency": "com.google.guava:guava", "versions": ["16.0.1", "20.0"]}]}""".stripMargin
   )
 
   testLintResults(
@@ -98,7 +98,7 @@ class LintCommandSuite extends BaseSuite with ConfigSyntax {
     ),
     expectedExitCode = 100,
     expectedReport =
-      """|"//foo:foo": {"failure": true, "conflicts": {"com.google.guava:guava": ["16.0.1", "20.0"]}}""".stripMargin
+      """|- {"target": "//foo:foo", "failure": true, "conflicts": [{"dependency": "com.google.guava:guava", "versions": ["16.0.1", "20.0"]}]}""".stripMargin
   )
 
   testLintResults(
@@ -116,9 +116,8 @@ class LintCommandSuite extends BaseSuite with ConfigSyntax {
       lintError("com.google.guava", "guava", "20.0", "16.0.1").copy(target = "//foo:my-alias")
     ),
     expectedExitCode = 100,
-    expectedReport =
-      """|"//foo:foo": {"failure": true, "conflicts": {"com.google.guava:guava": ["16.0.1", "20.0"]}}
-       |"//foo:my-alias": {"failure": true, "conflicts": {"com.google.guava:guava": ["16.0.1", "20.0"]}}""".stripMargin
+    expectedReport = """|- {"target": "//foo:foo", "failure": true, "conflicts": [{"dependency": "com.google.guava:guava", "versions": ["16.0.1", "20.0"]}]}
+                         |- {"target": "//foo:my-alias", "failure": true, "conflicts": [{"dependency": "com.google.guava:guava", "versions": ["16.0.1", "20.0"]}]}""".stripMargin
   )
 
   private def testLintResults(


### PR DESCRIPTION
**Problem**
Current YAML report does not provide the key-value structure that is required by most YAML parsers
The structure requirement is for object to have a generic key names
Right now we're using target/dependency names, which are too specific, as our key names

**Solution**
Edit the YAML report produced to satisfy the structure requirement of most YAML parsers
