### PR TITLE
Support setting the URL of the JAR to resolve

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
@@ -361,7 +361,7 @@ case class ExportCommand(
    * `failOnEvictedDeclared` is set, then an error will be returned when such
    * dependencies are found.
    *
-   * When a declared dependency is evicted and sets the URL of the JAR to resole, then the
+   * When a declared dependency is evicted and sets the URL of the JAR to resolve, then the
    * message will always be considered an error, regardless of `failOnEvictedDeclared`.
    *
    * @param originalThirdParty    The original third party configuration, as configured in the

--- a/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
@@ -30,15 +30,19 @@ import moped.json.Result
 import moped.json.ValueResult
 import moped.progressbars.ProgressRenderer
 import moped.reporters.Diagnostic
+import moped.reporters.ErrorSeverity
 import moped.reporters.Input
 import moped.reporters.NoPosition
+import moped.reporters.WarningSeverity
 import multiversion.configs.DependencyConfig
 import multiversion.configs.ModuleConfig
 import multiversion.configs.ThirdpartyConfig
 import multiversion.diagnostics.ConflictingTransitiveDependencyDiagnostic
 import multiversion.diagnostics.EvictedDeclaredDependencyDiagnostic
+import multiversion.diagnostics.ForbiddenUrlAttributeDiagnostic
 import multiversion.diagnostics.IntraTargetConflictDiagnostic
 import multiversion.diagnostics.MultidepsEnrichments._
+import multiversion.diagnostics.TransitiveUrlDiagnostic
 import multiversion.loggers._
 import multiversion.outputs.ArtifactOutput
 import multiversion.outputs.DependencyResolution
@@ -67,6 +71,8 @@ case class ExportCommand(
     parallelDownload: Option[Int] = None,
     @Description("Report an error if a declared dependency is evicted")
     failOnEvictedDeclared: Boolean = true,
+    @Description("Whether to allow `url` attribute in dependency configurations")
+    allowUrl: Boolean = true,
 ) extends Command {
   def app = lintCommand.app
   def run(): Int = {
@@ -100,15 +106,16 @@ case class ExportCommand(
         .withRetry(retryCount)
 
       for {
-        initialResolutions <- runResolutions(thirdparty, thirdparty.coursierDeps, coursierCache)
-        initialIndex = ResolutionIndex.fromResolutions(thirdparty, initialResolutions)
-        withSelectedVersions = selectVersionsFromIndex(thirdparty, initialIndex)
+        withUrls <- lintUrls(thirdparty, allowUrl)
+        initialResolutions <- runResolutions(withUrls, withUrls.coursierDeps, coursierCache)
+        initialIndex = ResolutionIndex.fromResolutions(withUrls, initialResolutions)
+        withSelectedVersions = selectVersionsFromIndex(withUrls, initialIndex)
         withOverriddenTargets = overrideTargets(withSelectedVersions, initialIndex)
         resolutions <-
           runResolutions(withOverriddenTargets, withOverriddenTargets.coursierDeps, coursierCache)
         index = ResolutionIndex.fromResolutions(withOverriddenTargets, resolutions)
         _ <- lintEvictedDeclaredDependencies(
-          thirdparty,
+          withUrls,
           initialIndex,
           index,
           failOnEvictedDeclared
@@ -154,6 +161,40 @@ case class ExportCommand(
     VersionCompatibility.PackVer -> "pvp",
     VersionCompatibility.Strict -> "strict"
   )
+
+  /**
+   * Report errors for dependencies that set the URL of the JAR to resolve when
+   * `allowUrl` is not set, and report warnings for dependencies that set the URL of the JAR
+   * to resolve, but do not set the intransitive flag.
+   *
+   * @param thirdparty The third party configuration
+   * @param allowUrl   Whether setting the URL of the JAR in a dependency is allowed
+   * @return The new third party configuration where dependencies that set the URl of the JAR
+   * to resolve are all marked `intransitive`.
+   */
+  private def lintUrls(
+      thirdparty: ThirdpartyConfig,
+      allowUrl: Boolean
+  ): Result[ThirdpartyConfig] = {
+    val diagnostics = thirdparty.dependencies.flatMap { dep =>
+      val forbiddenUrl =
+        if (dep.url.isDefined && !allowUrl)
+          List(new ForbiddenUrlAttributeDiagnostic(dep.targets, dep.organization.position))
+        else Nil
+      val transitiveUrl =
+        if (dep.url.isDefined && dep.transitive)
+          List(new TransitiveUrlDiagnostic(dep.targets, dep.organization.position))
+        else Nil
+      forbiddenUrl ++ transitiveUrl
+    }
+
+    val newDependencies = thirdparty.dependencies.map {
+      case dep if dep.url.isDefined && dep.transitive => dep.copy(transitive = false)
+      case dep                                        => dep
+    }
+
+    app.reportOrElse(diagnostics, thirdparty.copy(dependencies = newDependencies))
+  }
 
   /**
    * Re-configure the dependencies whose resolution include overridden targets
@@ -320,6 +361,9 @@ case class ExportCommand(
    * `failOnEvictedDeclared` is set, then an error will be returned when such
    * dependencies are found.
    *
+   * When a declared dependency is evicted and sets the URL of the JAR to resole, then the
+   * message will always be considered an error, regardless of `failOnEvictedDeclared`.
+   *
    * @param originalThirdParty    The original third party configuration, as configured in the
    *                              input file.
    * @param originalIndex         The resolution index built after the first resolution.
@@ -335,10 +379,6 @@ case class ExportCommand(
       index: ResolutionIndex,
       failOnEvictedDeclared: Boolean
   ): Result[Unit] = {
-    val severity =
-      if (failOnEvictedDeclared) moped.reporters.ErrorSeverity
-      else moped.reporters.WarningSeverity
-
     def selectedDependencyOf(config: DependencyConfig): Dependency = {
       val originalDependency = config.toCoursierDependency(originalThirdParty.scala)
       // The original dependency could have been evicted after the first resolution already,
@@ -372,29 +412,19 @@ case class ExportCommand(
         selectedDependency = selectedDependencyOf(dependency)
         if declaredDependency.version != selectedDependency.version && dependency.force
         breakingTargets = targetsDependingOn(selectedDependency) -- declaringTargets
+        severity =
+          if (dependency.url.isDefined || failOnEvictedDeclared) ErrorSeverity else WarningSeverity
       } yield new EvictedDeclaredDependencyDiagnostic(
         declaredDependency,
         declaringTargets,
         selectedDependency,
         breakingTargets,
+        hasUrl = dependency.url.isDefined,
         severity,
         dependency.organization.position
       )
 
-    if (failOnEvictedDeclared) {
-      Diagnostic.fromDiagnostics(diagnostics) match {
-        case Some(diagnostic) => ErrorResult(diagnostic)
-        case None             => ValueResult(())
-      }
-    } else {
-      diagnostics.foreach(app.reporter.log)
-      if (diagnostics.length == 1) {
-        app.reporter.warning("1 declared dependency was evicted.")
-      } else if (diagnostics.length > 1) {
-        app.reporter.warning(s"${diagnostics.length} declared dependencies were evicted.")
-      }
-      ValueResult(())
-    }
+    app.reportOrElse(diagnostics, ())
   }
 
   /**

--- a/multiversion/src/main/scala/multiversion/configs/DependencyConfig.scala
+++ b/multiversion/src/main/scala/multiversion/configs/DependencyConfig.scala
@@ -29,6 +29,7 @@ final case class DependencyConfig(
     organization: JsonString = JsonString(""),
     name: String = "",
     version: String = "",
+    url: Option[String] = None,
     classifier: Option[String] = None,
     exclusions: Set[ModuleConfig] = Set.empty,
     crossVersions: List[CrossVersionsConfig] = Nil,

--- a/multiversion/src/main/scala/multiversion/diagnostics/EvictedDeclaredDependencyDiagnostic.scala
+++ b/multiversion/src/main/scala/multiversion/diagnostics/EvictedDeclaredDependencyDiagnostic.scala
@@ -11,16 +11,25 @@ class EvictedDeclaredDependencyDiagnostic(
     declaringTargets: Iterable[String],
     selectedDependency: Dependency,
     breakingTargets: Iterable[String],
+    hasUrl: Boolean,
     severity: Severity,
     pos: Position
 ) extends Diagnostic(severity, "", pos) {
+  private val urlInfos =
+    if (hasUrl)
+      List(
+        "  This dependency defines the URL of the JAR to resolve, forcing this message to the ERROR level."
+      )
+    else Nil
+  private val infos = urlInfos ++ List(
+    s"  '${declaredDependency.repr}' is declared in ${declaringTargets.toList.sorted.mkString(", ")}.",
+    s"  '${selectedDependency.repr}' is a transitive dependency of ${breakingTargets.toList.sorted.mkString(", ")}."
+  )
+
   override def message: String = {
     s"""|Declared third party dependency '${declaredDependency.repr}' is evicted in favor of '${selectedDependency.repr}'.
         |Update the third party declaration to use version '${selectedDependency.version}' instead of '${declaredDependency.version}' to reflect the effective dependency graph.
         |Info:
-        |  '${declaredDependency.repr}' is declared in ${declaringTargets.toList.sorted
-      .mkString(", ")}.
-        |  '${selectedDependency.repr}' is a transitive dependency of ${breakingTargets.toList.sorted
-      .mkString(", ")}.""".stripMargin
+        |${infos.mkString(System.lineSeparator)}""".stripMargin
   }
 }

--- a/multiversion/src/main/scala/multiversion/diagnostics/ForbiddenUrlAttributeDiagnostic.scala
+++ b/multiversion/src/main/scala/multiversion/diagnostics/ForbiddenUrlAttributeDiagnostic.scala
@@ -1,0 +1,17 @@
+package multiversion.diagnostics
+
+import moped.reporters.Diagnostic
+import moped.reporters.ErrorSeverity
+import moped.reporters.Position
+import multiversion.diagnostics.MultidepsEnrichments._
+
+class ForbiddenUrlAttributeDiagnostic(
+    targets: List[String],
+    pos: Position
+) extends Diagnostic(ErrorSeverity, "", pos) {
+  override def message: String = {
+    s"""|The third party dependency declaration in ${targets.commas} is defining the URL of the JAR
+        |to resolve, which is not permitted.
+        |""".stripMargin
+  }
+}

--- a/multiversion/src/main/scala/multiversion/diagnostics/TransitiveUrlDiagnostic.scala
+++ b/multiversion/src/main/scala/multiversion/diagnostics/TransitiveUrlDiagnostic.scala
@@ -1,0 +1,17 @@
+package multiversion.diagnostics
+
+import moped.reporters.Diagnostic
+import moped.reporters.Position
+import moped.reporters.WarningSeverity
+import multiversion.diagnostics.MultidepsEnrichments._
+
+class TransitiveUrlDiagnostic(
+    targets: List[String],
+    pos: Position
+) extends Diagnostic(WarningSeverity, "", pos) {
+  override def message: String = {
+    s"""|The third party dependency declaration in ${targets.commas} is defining the URL of the JAR
+        |to resolve, but isn't marked as intransitive. It will be considered intransitive.
+        |""".stripMargin
+  }
+}

--- a/tests/src/main/scala/tests/ConfigSyntax.scala
+++ b/tests/src/main/scala/tests/ConfigSyntax.scala
@@ -20,6 +20,7 @@ trait ConfigSyntax {
           org,
           name,
           version,
+          url = None,
           classifier = None,
           dependencies = Nil,
           exclusions = Nil,
@@ -47,6 +48,7 @@ object ConfigNode {
       organization: String,
       name: String,
       version: String,
+      url: Option[String],
       classifier: Option[String],
       dependencies: List[String],
       exclusions: List[Exclusion],
@@ -55,6 +57,9 @@ object ConfigNode {
       transitive: Boolean,
       versionPattern: Option[String]
   ) extends ConfigNode {
+
+    def url(url: String): Dependency =
+      copy(url = Option(url))
 
     def classifier(classifier: String): Dependency =
       copy(classifier = Option(classifier))
@@ -105,6 +110,7 @@ object ConfigNode {
         }
 
       s"""|  - dependency: $organization:$name:$version
+          |    url: ${url.orNull}
           |    classifier: ${classifier.orNull}
           |    force: $force
           |    transitive: $transitive

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -51,7 +51,7 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
          |  'org.slf4j:slf4j-log4j12:1.6.4' is a transitive dependency of slf4j-1.6.4.
          |  - dependency: org.slf4j:slf4j-log4j12:1.6.1
          |                ^
-         |warning: 1 declared dependency was evicted.
+         |warning: 1 warning(s) found.
          |""".stripMargin + defaultExpectedOutput
   )
 
@@ -89,7 +89,7 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
          |  'io.netty:netty:3.10.1.Final' is a transitive dependency of netty-310.
          |  - dependency: io.netty:netty:3.7.0.Final
          |                ^
-         |warning: 1 declared dependency was evicted.
+         |warning: 1 warning(s) found.
          |""".stripMargin + defaultExpectedOutput
   )
 
@@ -167,7 +167,7 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
          |  'org.apache.kafka:kafka-clients:2.4.1' is a transitive dependency of client-2.4.1.
          |  - dependency: org.apache.kafka:kafka-clients:2.4.0
          |                ^
-         |warning: 1 declared dependency was evicted.
+         |warning: 1 warning(s) found.
          |""".stripMargin + defaultExpectedOutput,
   )
 
@@ -260,7 +260,7 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
          |  'org.apache.kafka:kafka-clients:2.4.1' is a transitive dependency of kafka-clients-2.4.1.
          |  - dependency: org.apache.kafka:kafka-clients:2.4.0
          |                ^
-         |warning: 1 declared dependency was evicted.
+         |warning: 1 warning(s) found.
          |""".stripMargin + defaultExpectedOutput
   )
 
@@ -407,14 +407,14 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
         """|@maven//:org.apiguardian/apiguardian-api/1.1.1.jar""".stripMargin
     ),
     expectedOutput =
-      """|/workingDirectory/3rdparty.yaml:14:16 warning: Declared third party dependency 'org.apiguardian:apiguardian-api:1.1.0' is evicted in favor of 'org.apiguardian:apiguardian-api:1.1.1'.
+      """|/workingDirectory/3rdparty.yaml:15:16 warning: Declared third party dependency 'org.apiguardian:apiguardian-api:1.1.0' is evicted in favor of 'org.apiguardian:apiguardian-api:1.1.1'.
          |Update the third party declaration to use version '1.1.1' instead of '1.1.0' to reflect the effective dependency graph.
          |Info:
          |  'org.apiguardian:apiguardian-api:1.1.0' is declared in apiguardian-old.
          |  'org.apiguardian:apiguardian-api:1.1.1' is a transitive dependency of apiguardian.
          |  - dependency: org.apiguardian:apiguardian-api:1.1.0
          |                ^
-         |warning: 1 declared dependency was evicted.
+         |warning: 1 warning(s) found.
          |""".stripMargin + defaultExpectedOutput
   )
 
@@ -437,14 +437,14 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
         """|@maven//:org.apiguardian/apiguardian-api/1.1.1.jar""".stripMargin
     ),
     expectedOutput =
-      """|/workingDirectory/3rdparty.yaml:25:16 warning: Declared third party dependency 'org.apiguardian:apiguardian-api:1.1.0' is evicted in favor of 'org.apiguardian:apiguardian-api:1.1.1'.
+      """|/workingDirectory/3rdparty.yaml:27:16 warning: Declared third party dependency 'org.apiguardian:apiguardian-api:1.1.0' is evicted in favor of 'org.apiguardian:apiguardian-api:1.1.1'.
          |Update the third party declaration to use version '1.1.1' instead of '1.1.0' to reflect the effective dependency graph.
          |Info:
          |  'org.apiguardian:apiguardian-api:1.1.0' is declared in apiguardian-old.
          |  'org.apiguardian:apiguardian-api:1.1.1' is a transitive dependency of multi-jar.
          |  - dependency: org.apiguardian:apiguardian-api:1.1.0
          |                ^
-         |warning: 1 declared dependency was evicted.
+         |warning: 1 warning(s) found.
          |""".stripMargin + defaultExpectedOutput
   )
 
@@ -552,7 +552,7 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
          |  'org.apache.parquet:parquet-thrift:1.11.0' is a transitive dependency of parquet-thrift-1.11.0.
          |  - dependency: org.apache.parquet:parquet-thrift:1.9.0
          |                ^
-         |warning: 1 declared dependency was evicted.
+         |warning: 1 warning(s) found.
          |""".stripMargin + defaultExpectedOutput
   )
 
@@ -616,7 +616,7 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
     ),
     expectedExit = 1,
     expectedOutput =
-      """|/workingDirectory/3rdparty.yaml:14:16 error: Within 'broken-target', the module 'com.google.guava:guava' is resolved multiple times with incompatible versions 16.0.1, 30.1.1-jre.
+      """|/workingDirectory/3rdparty.yaml:15:16 error: Within 'broken-target', the module 'com.google.guava:guava' is resolved multiple times with incompatible versions 16.0.1, 30.1.1-jre.
          |To fix this problem, update your dependencies to compatible versions, or add exclusion rules to force compatible versions of 'com.google.guava:guava'.
          |
          |  - dependency: com.google.inject:guice:4.0
@@ -672,7 +672,98 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
          |  'com.google.apis:google-api-services-storage:v1-rev20200326-1.30.9' is a transitive dependency of storage-1.30.9.
          |  - dependency: com.google.apis:google-api-services-storage:v1-rev20190624-1.30.1
          |                ^
-         |warning: 1 declared dependency was evicted.
+         |warning: 1 warning(s) found.
          |""".stripMargin + defaultExpectedOutput
+  )
+
+  checkMultipleDeps(
+    "custom URL",
+    deps(
+      dep("com.nimbusds:nimbus-jose-jwt:4.41.1")
+        .url(
+          "https://repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar"
+        )
+        .target("with-url")
+        .transitive(false)
+    ),
+    extraBuild = """|/foo/BUILD
+                    |load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library", "scala_binary")
+                    |
+                    |scala_library(
+                    |  name = "bar",
+                    |  srcs = ["A.scala"],
+                    |  deps = ["@maven//:with-url"]
+                    |)
+                    |/foo/A.scala
+                    |import org.apiguardian.api.API // wouldn't compile without `url = ...`
+                    |object A""".stripMargin,
+    buildQuery = "foo:bar"
+  )
+
+  checkMultipleDeps(
+    "warn about transitive deps with custom URLs",
+    deps(
+      dep("com.nimbusds:nimbus-jose-jwt:4.41.1")
+        .url(
+          "https://repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar"
+        )
+        .target("with-url")
+        .transitive(true)
+    ),
+    expectedOutput =
+      """|/workingDirectory/3rdparty.yaml:3:16 warning: The third party dependency declaration in with-url is defining the URL of the JAR
+         |to resolve, but isn't marked as intransitive. It will be considered intransitive.
+         |
+         |  - dependency: com.nimbusds:nimbus-jose-jwt:4.41.1
+         |                ^
+         |warning: 1 warning(s) found.
+         |""".stripMargin + defaultExpectedOutput
+  )
+
+  checkMultipleDeps(
+    "reject custom URL when configured to",
+    deps(
+      dep("com.nimbusds:nimbus-jose-jwt:4.41.1")
+        .url(
+          "https://repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar"
+        )
+        .target("with-url")
+        .transitive(false)
+    ),
+    arguments = exportCommand :+ "--no-allow-url",
+    expectedOutput =
+      """|/workingDirectory/3rdparty.yaml:3:16 error: The third party dependency declaration in with-url is defining the URL of the JAR
+         |to resolve, which is not permitted.
+         |
+         |  - dependency: com.nimbusds:nimbus-jose-jwt:4.41.1
+         |                ^
+         |""".stripMargin,
+    expectedExit = 1
+  )
+
+  checkMultipleDeps(
+    "error when dep with custom URL is evicted",
+    deps(
+      dep("commons-logging:commons-logging:1.0")
+        .target("with-url")
+        .transitive(false)
+        .url(
+          "https://repo1.maven.org/maven2/org/commons-logging/commons-logging/1.0/commons-logging-1.0.jar"
+        ),
+      dep("commons-logging:commons-logging:1.2")
+        .target("commons-logging")
+    ),
+    arguments = exportCommand :+ "--no-fail-on-evicted-declared",
+    expectedOutput =
+      """|/workingDirectory/3rdparty.yaml:3:16 error: Declared third party dependency 'commons-logging:commons-logging:1.0' is evicted in favor of 'commons-logging:commons-logging:1.2'.
+         |Update the third party declaration to use version '1.2' instead of '1.0' to reflect the effective dependency graph.
+         |Info:
+         |  This dependency defines the URL of the JAR to resolve, forcing this message to the ERROR level.
+         |  'commons-logging:commons-logging:1.0' is declared in with-url.
+         |  'commons-logging:commons-logging:1.2' is a transitive dependency of commons-logging.
+         |  - dependency: commons-logging:commons-logging:1.0
+         |                ^
+         |""".stripMargin,
+    expectedExit = 1
   )
 }


### PR DESCRIPTION
Previously, multiversion didn't have an option to manually force the URL
of a JAR to resolve, which made it harder for developers to test targets
with a custom built JAR.

This commit adds an attribute `url` to the `DependencyConfig` where the
URL of the JAR to resolve can be set. Whether multiversion should allow
`url` in the dependency configuration can be controller with
`--[no-]allow-url`.

Following the Coursier semantics of the `url=...` attribute,
dependencies that set the URL will be resolve intransitively.
Dependencies that set the URL but are not marked as intransitive will
trigger a warning message, and the resolution will be done
intransitively.

Dependencies that set the URL, but are evicted will trigger an error,
regardless of `--no-fail-on-evicted-declared`.