### PR TITLE
Fix missing targets when deps are duplicated

### DIFF
--- a/multiversion/src/main/scala/multiversion/configs/ThirdpartyConfig.scala
+++ b/multiversion/src/main/scala/multiversion/configs/ThirdpartyConfig.scala
@@ -86,7 +86,7 @@ final case class ThirdpartyConfig(
   def coursierDeps: List[(DependencyConfig, Dependency)] =
     dependencies2
       .flatMap(d => d.coursierDependencies(scala).map(cd => d -> cd))
-      .distinctBy(_._2)
+      .distinctBy { case (d, cd) => (d.targets.sorted, cd) }
   def relaxedForAllModules: Seq[(ModuleMatchers, Reconciliation)] =
     Vector((ModuleMatchers.all, Reconciliation.Relaxed))
 

--- a/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
+++ b/tests/src/test/scala/tests/commands/ExportCommandSuite.scala
@@ -766,4 +766,38 @@ class ExportCommandSuite extends tests.BaseSuite with tests.ConfigSyntax {
          |""".stripMargin,
     expectedExit = 1
   )
+
+  checkMultipleDeps(
+    "different targets with the same dependencies",
+    deps(
+      dep("org.apiguardian:apiguardian-api:1.1.1")
+        .target("apiguardian"),
+      dep("org.apiguardian:apiguardian-api:1.1.1")
+        .target("apiguardian-2"),
+      dep("io.netty:netty:3.10.1.Final")
+        .target("netty"),
+      dep("commons-codec:commons-codec:1.9")
+        .target("target-0")
+        .transitive(false)
+        .dependency("netty")
+        .dependency("apiguardian-2")
+        .force(false),
+      dep("commons-codec:commons-codec:1.8")
+        .target("target-1")
+        .transitive(false)
+        .dependency("apiguardian")
+        .dependency("netty")
+        .force(true)
+    ),
+    queries = List(
+      allJars("@maven//:target-0") ->
+        """|@maven//:commons-codec/commons-codec/commons-codec-1.8.jar
+           |@maven//:io.netty/netty/netty-3.10.1.Final.jar
+           |@maven//:org.apiguardian/apiguardian-api/apiguardian-api-1.1.1.jar""".stripMargin,
+      allJars("@maven//:target-1") ->
+        """|@maven//:commons-codec/commons-codec/commons-codec-1.8.jar
+           |@maven//:io.netty/netty/netty-3.10.1.Final.jar
+           |@maven//:org.apiguardian/apiguardian-api/apiguardian-api-1.1.1.jar""".stripMargin,
+    )
+  )
 }


### PR DESCRIPTION
Previously, if the same third party dependency was defined by several
targets (before or after reconciliation), then multiversion generated a
graph that was missing some nodes.

The root cause is that when dependencies were de-duplicated, the
different targets were not taken into account, and some targets were
then associated with no resolution.

This commit fixes it by taking the targets for which the resolution is
performed into account when de-duplicating the dependencies.