### PR TITLE
Fix BUILDish on GraalVM native image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,11 @@ jobs:
         with:
           version: "3.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: cd multiversion-example && bazel build tricky/...
+      - name: multiversion-example
+        shell: bash
+        run: |
+          cd multiversion-example
+          bazel build tricky/...
       - run: sbt test
   graalnative:
     name: GraalVM Native Image
@@ -46,7 +50,9 @@ jobs:
         version: "3.x"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
-      run: sbt -v -Dfile.encoding=UTF8 nativeImage
+      run: |
+        sbt -v -Dfile.encoding=UTF8 nativeImage
+        chmod +x multiversion/target/native-image/multiversion
       shell: bash
     - name: Archive native image artifacts
       uses: actions/upload-artifact@v2

--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,7 @@ lazy val multiversion = project
       "--initialize-at-build-time=scala.collection.immutable.VM",
       "--initialize-at-run-time=multiversion,moped.cli.Environment$",
       "-H:+TraceClassInitialization",
+      s"-H:ReflectionConfigurationFiles=${baseDirectory.value}/reflect.config",
       "--enable-http",
       "--enable-https",
       "--report-unsupported-elements-at-runtime"

--- a/multiversion-example/bin/multiversion
+++ b/multiversion-example/bin/multiversion
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash -e
+
+MULTIVERSION_VER="0.1.0"
+DOWNLOAD_BASE_URL="https://github.com/twitter/bazel-multiversion/releases/download"
+X86_LINUX_APP_NAME="multiversion-x86_64-pc-linux"
+X86_DARWIN_APP_NAME="multiversion-x86_64-apple-darwin"
+
+download_url () {
+  local url="$1"
+  local target="$2"
+  mkdir -p $(dirname "$target") && {
+    if command -v curl > /dev/null; then
+      curl --silent -L "$url" --output "$target"
+    elif command -v wget > /dev/null; then
+      wget --quiet -O "$target" "$url"
+    fi
+  } && [[ -f "$target" ]]
+}
+
+echoerr () {
+  echo 1>&2 "$@"
+}
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  MULTIVERSION_URL="$DOWNLOAD_BASE_URL/v$MULTIVERSION_VER/$X86_LINUX_APP_NAME"
+  TARGET_APP="$HOME/.cache/bazel-multiversion/v$MULTIVERSION_VER/$X86_LINUX_APP_NAME"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  MULTIVERSION_URL="$DOWNLOAD_BASE_URL/v$MULTIVERSION_VER/$X86_DARWIN_APP_NAME"
+  TARGET_APP="$HOME/.cache/bazel-multiversion/v$MULTIVERSION_VER/$X86_DARWIN_APP_NAME"
+else
+  echoerr unsupported operating system
+  exit 1
+fi
+
+if ! [[ -f "$TARGET_APP" ]]; then
+  echoerr $TARGET_APP
+  echoerr downloading multiversion $MULTIVERSION_VER
+  download_url "$MULTIVERSION_URL" "$TARGET_APP"
+  chmod +x "$TARGET_APP"
+fi
+
+exec "$TARGET_APP" "$@"

--- a/multiversion/reflect.config
+++ b/multiversion/reflect.config
@@ -1,0 +1,11 @@
+[
+  {
+    "name" : "multiversion.buildish.Functions",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredClasses" : true,
+    "allPublicClasses" : true
+  }
+]


### PR DESCRIPTION
Problem
-------
0.1.0 can't import BUILDish.
I originally tested only using JVM artifact, for native image requires a
helper file to register reflection.