### PR TITLE
Implement rules_jvm_export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: multiversion-example
         shell: bash
-        run: |
-          cd multiversion-example
-          bazel build tricky/...
+        run: scripts/ci-test.sh
       - run: sbt test
   graalnative:
     name: GraalVM Native Image

--- a/NOTICE
+++ b/NOTICE
@@ -208,3 +208,14 @@ We include the text of the original license below.
    See the License for the specific language governing permissions and
    limitations under the License.
 ```
+
+# License notice for bazel-distribution
+
+This project contains parts which are derived from
+[bazel-distribution](https://github.com/vaticle/bazel-distribution).
+Specifically rules_jvm_export was copy-pasted from
+https://github.com/vaticle/bazel-distribution/blob/master/maven/rules.bzl
+and adapted to the needs of this project.
+
+bazel-distribution is developed by Vatice, and licensed under Apache License 2.0.
+

--- a/multiversion-example/WORKSPACE
+++ b/multiversion-example/WORKSPACE
@@ -58,3 +58,7 @@ jvm_deps()
 load("@maven//:jvm_deps.bzl", "load_jvm_deps")
 load_jvm_deps()
 
+local_repository(
+    name = "twitter_rules_jvm_export",
+    path = "../rules_jvm_export"
+)

--- a/multiversion-example/export-example/BUILD
+++ b/multiversion-example/export-example/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+load("@twitter_rules_jvm_export//jvm_export:jvm_export.bzl", "jvm_export")
+
+scala_library(
+    name = "io1",
+    srcs = ["IO1.scala"],
+    tags = [
+        "maven_coordinates=com.twitter.dpb:io1:{pom_version}",
+    ],
+    deps = [
+        "@maven//:3rdparty/jvm/com/google/guava/guava",
+    ],
+)
+
+jvm_export(
+    name = "io1.publish",
+    target = ":io1",
+    project_name = "IO 1",
+    project_description = "IO library",
+    project_url = "http://example.com/",
+    license = "Apache-2.0",
+    scm_url = "http://github.com/",
+    release_repo = "https://localhost/",
+    snapshot_repo = "https://localhost/",
+    # python_path = "/opt/ee/python/3.10/bin/python3.10",
+)

--- a/multiversion-example/export-example/IO1.scala
+++ b/multiversion-example/export-example/IO1.scala
@@ -1,0 +1,3 @@
+package com.twitter.dpb
+
+case class IO1()

--- a/rules_jvm_export/README.md
+++ b/rules_jvm_export/README.md
@@ -1,0 +1,62 @@
+rules_jvm_export
+================
+
+## Publishing to external repositories
+
+```python
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+load("@twitter_rules_jvm_export//jvm_export:jvm_export.bzl", "jvm_export")
+
+scala_library(
+    name = "io1",
+    srcs = ["IO1.scala"],
+    tags = [
+        "maven_coordinates=com.example:io1:{pom_version}",
+    ],
+    deps = [
+        "@maven//:3rdparty/jvm/com/google/guava/guava",
+    ],
+)
+
+jvm_export(
+    name = "io1.publish",
+    target = ":io1",
+    project_name = "IO 1",
+    project_description = "IO library",
+    project_url = "http://example.com/",
+    license = "Apache-2.0",
+    scm_url = "http://github.com/",
+    release_repo = "https://localhost/",
+    snapshot_repo = "https://localhost/",
+    python_path = "/usr/bin/env python",
+)
+```
+
+To publish using `.netrc` authentication:
+
+```bash
+$ bazel run //:io1.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release --netrc
+```
+
+To publish with environment variable authentication, set `SONATYPE_USERNAME` and `SONATYPE_PASSWORD`, then run:
+
+```bash
+$ bazel run //:io1.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release
+```
+
+To publish to local `~/.m2/repository/`:
+
+```bash
+$ bazel run //:io1.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release --local
+```
+
+## Credits
+
+- rules_jvm_export was inspired by [bazel-distribution][bazel-distribution] developed by Vaticle.
+  In fact, the rules implementation is based off of bazel-distribution for the most part.
+  Instead of using Kotlin, we have reimplemented the helper programs to use Python instead.
+  Also instead of assembling JAR files, rules_jvm_export uses the normal `build` artifacts by default.
+- [rules_jvm_external][rules_jvm_external] was also an inspiration for its simplicity.
+
+  [bazel-distribution]: https://github.com/vaticle/bazel-distribution
+  [rules_jvm_external]: https://github.com/bazelbuild/rules_jvm_external

--- a/rules_jvm_export/WORKSPACE
+++ b/rules_jvm_export/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "twitter_rules_jvm_export")

--- a/rules_jvm_export/jvm_export/BUILD
+++ b/rules_jvm_export/jvm_export/BUILD
@@ -1,0 +1,13 @@
+load("jvm_export.bzl", "jvm_export_version")
+
+exports_files(
+    glob([
+        "*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+jvm_export_version(
+    name = "version",
+    version = "0.0.0",
+)

--- a/rules_jvm_export/jvm_export/jvm_export.bzl
+++ b/rules_jvm_export/jvm_export/jvm_export.bzl
@@ -1,0 +1,418 @@
+# Based on https://github.com/vaticle/bazel-distribution/blob/master/maven/rules.bzl
+# SPDX-License-Identifier: Apache-2.0
+
+JvmExportInfo = provider(
+    fields={
+        "jar": "JAR file to deploy",
+        "srcjar": "JAR file with sources",
+        "pom": "Accompanying pom.xml file",
+    }
+)
+
+
+VersionInfo = provider(
+    doc="A singleton provider that contains the raw value of a build setting",
+    fields={"value": "Version number"},
+)
+
+
+def _jvm_export_impl(ctx):
+    version = ctx.attr.version[VersionInfo].value
+    pom_file = _generate_pom_file(ctx, version)
+    if ctx.attr.assemble:
+        class_jar = _generate_class_jar(ctx, pom_file)
+    else:
+        class_jar = _class_jar(ctx.attr.target)
+    source_jar = _generate_source_jar(ctx)
+
+    deploy_script = ctx.actions.declare_file(
+        "jvm-export/{}-deploy.py".format(ctx.attr.name)
+    )
+    lib_jar_link = "lib.jar"
+    src_jar_link = "lib.srcjar"
+    pom_xml_link = pom_file.basename
+    ctx.actions.expand_template(
+        template=ctx.file._deployment,
+        output=deploy_script,
+        substitutions={
+            "$JAR_PATH": lib_jar_link,
+            "$SRCJAR_PATH": src_jar_link,
+            "$POM_PATH": pom_xml_link,
+            "$PYTHON_PATH": ctx.attr.python_path,
+            "{snapshot}": ctx.attr.snapshot_repo,
+            "{release}": ctx.attr.release_repo,
+        },
+    )
+    output_files = [pom_file, class_jar]
+
+    symlinks = {
+        lib_jar_link: class_jar,
+        pom_xml_link: pom_file,
+    }
+    if source_jar:
+        output_files.append(source_jar)
+        symlinks[src_jar_link] = source_jar
+
+    return [
+        DefaultInfo(
+            executable=deploy_script,
+            files=depset(output_files),
+            runfiles=ctx.runfiles(files=output_files, symlinks=symlinks),
+        ),
+        JvmExportInfo(
+            jar=class_jar,
+            pom=pom_file,
+            srcjar=source_jar,
+        ),
+    ]
+
+
+def _parse_maven_coordinates(coordinates_string, enforce_version_template=True):
+    coordinates = coordinates_string.split(":")
+    # Maven coordinates in the bazel ecosystem can include more than three fields.
+    # The group and artifact IDs are always the first 2 and the version is always the last field.
+    group_id, artifact_id = coordinates[0:2]
+    version = coordinates[-1]
+    if enforce_version_template and version != "{pom_version}":
+        fail("should assign {pom_version} as Maven version via `tags` attribute")
+    return struct(group_id=group_id, artifact_id=artifact_id, version=version)
+
+
+def _generate_pom_file(ctx, version):
+    target = ctx.attr.target
+    maven_coordinates = _parse_maven_coordinates(target[JarInfo].name)
+    pom_file = ctx.actions.declare_file("{}_pom.xml".format(ctx.attr.name))
+
+    pom_deps = []
+    for pom_dependency in [
+        dep for dep in target[JarInfo].deps.to_list() if dep.type == "pom"
+    ]:
+        pom_dependency = pom_dependency.maven_coordinates
+        if pom_dependency == target[JarInfo].name:
+            continue
+        pom_dependency_coordinates = _parse_maven_coordinates(pom_dependency, False)
+        pom_dependency_artifact = (
+            pom_dependency_coordinates.group_id
+            + ":"
+            + pom_dependency_coordinates.artifact_id
+        )
+        pom_dependency_version = pom_dependency_coordinates.version
+
+        v = ctx.attr.version_overrides.get(
+            pom_dependency_artifact, pom_dependency_version
+        )
+        pom_deps.append(pom_dependency_artifact + ":" + v)
+
+    pom_gen_script = ctx.actions.declare_file(
+        "jvm-export/{}-pom-gen.py".format(ctx.attr.name)
+    )
+    ctx.actions.expand_template(
+        template=ctx.file._pom_generator,
+        output=pom_gen_script,
+        substitutions={
+            "$PYTHON_PATH": ctx.attr.python_path,
+        },
+    )
+    ctx.actions.run(
+        executable=pom_gen_script,
+        inputs=[],
+        outputs=[pom_file],
+        arguments=[
+            "--group_id=" + maven_coordinates.group_id,
+            "--artifact_id=" + maven_coordinates.artifact_id,
+            "--version=" + version,
+            "--project_name=" + ctx.attr.project_name,
+            "--project_description=" + ctx.attr.project_description,
+            "--project_url=" + ctx.attr.project_url,
+            "--license=" + ctx.attr.license,
+            "--scm_url=" + ctx.attr.scm_url,
+            "--target_deps_coordinates=" + ";".join(pom_deps),
+            "--output_file=" + pom_file.path,
+        ],
+    )
+
+    return pom_file
+
+
+def _jar_assembler(ctx):
+    script = ctx.actions.declare_file(
+        "jvm-export/{}-jar-assembler.py".format(ctx.attr.name)
+    )
+    ctx.actions.expand_template(
+        template=ctx.file._jar_assembler,
+        output=script,
+        substitutions={
+            "$PYTHON_PATH": ctx.attr.python_path,
+        },
+    )
+    return script
+
+
+def _class_jar(target):
+    if len(target[JavaInfo].runtime_output_jars) == 1:
+        return target[JavaInfo].runtime_output_jars[0]
+    else:
+        fail(
+            "expected size 1, but runtime_output_jars in {} was {}".format(
+                target, target[JavaInfo].runtime_output_jars
+            )
+        )
+
+
+def _generate_class_jar(ctx, pom_file):
+    target = ctx.attr.target
+    maven_coordinates = _parse_maven_coordinates(target[JarInfo].name)
+
+    jar = _class_jar(target)
+    output_jar = ctx.actions.declare_file(
+        "{}:{}.jar".format(maven_coordinates.group_id, maven_coordinates.artifact_id)
+    )
+
+    class_jar_deps = [
+        dep.class_jar for dep in target[JarInfo].deps.to_list() if dep.type == "jar"
+    ]
+    class_jar_paths = [jar.path] + [target.path for target in class_jar_deps]
+
+    ctx.actions.run(
+        executable=_jar_assembler(ctx),
+        inputs=[jar, pom_file] + class_jar_deps,
+        outputs=[output_jar],
+        arguments=[
+            "--group_id=" + maven_coordinates.group_id,
+            "--artifact_id=" + maven_coordinates.artifact_id,
+            "--pom_file=" + pom_file.path,
+            "--output=" + output_jar.path,
+        ]
+        + class_jar_paths,
+    )
+
+    return output_jar
+
+
+def _generate_source_jar(ctx):
+    target = ctx.attr.target
+    maven_coordinates = _parse_maven_coordinates(target[JarInfo].name)
+
+    srcjar = None
+    if len(target[JavaInfo].source_jars) < 1:
+        fail("Could not find source JAR to deploy in {}".format(target))
+    else:
+        srcjar = target[JavaInfo].source_jars[0]
+
+    if not ctx.attr.assemble:
+        return srcjar
+
+    output_jar = ctx.actions.declare_file(
+        "{}:{}-sources.jar".format(
+            maven_coordinates.group_id, maven_coordinates.artifact_id
+        )
+    )
+
+    source_jar_deps = [
+        dep.source_jar
+        for dep in target[JarInfo].deps.to_list()
+        if dep.type == "jar" and dep.source_jar
+    ]
+    source_jar_paths = [srcjar.path] + [target.path for target in source_jar_deps]
+
+    ctx.actions.run(
+        executable=_jar_assembler(ctx),
+        inputs=[srcjar] + source_jar_deps,
+        outputs=[output_jar],
+        arguments=[
+            "--output=" + output_jar.path,
+        ]
+        + source_jar_paths,
+    )
+
+    return output_jar
+
+
+def find_maven_coordinates(target, tags):
+    _TAG_KEY_MAVEN_COORDINATES = "maven_coordinates="
+    _TAG_KEY_JVM_MODULE = "jvm_module="
+    _TAG_KEY_JVM_VERSION = "jvm_version="
+    mod = None
+    ver = None
+    for tag in tags:
+        if tag.startswith(_TAG_KEY_MAVEN_COORDINATES):
+            coordinates = tag[len(_TAG_KEY_MAVEN_COORDINATES) :]
+            return coordinates
+        elif tag.startswith(_TAG_KEY_JVM_MODULE):
+            mod = tag[len(_TAG_KEY_JVM_MODULE) :]
+        elif tag.startswith(_TAG_KEY_JVM_VERSION):
+            ver = tag[len(_TAG_KEY_JVM_VERSION) :]
+
+    if mod and ver:
+        return "{}:{}".format(mod, ver)
+
+
+JarInfo = provider(
+    fields={
+        "name": "The name of a the JAR (Maven coordinates)",
+        "deps": "The list of dependencies of this JAR. A dependency may be of two types, POM or JAR.",
+    },
+)
+
+
+def _aggregate_dependency_info_impl(target, ctx):
+    tags = getattr(ctx.rule.attr, "tags", [])
+    deps = getattr(ctx.rule.attr, "deps", [])
+    runtime_deps = getattr(ctx.rule.attr, "runtime_deps", [])
+    exports = getattr(ctx.rule.attr, "exports", [])
+    deps_all = deps + exports + runtime_deps
+
+    maven_coordinates = find_maven_coordinates(target, tags)
+    dependencies = []
+
+    # depend via POM
+    if maven_coordinates:
+        dependencies = [struct(type="pom", maven_coordinates=maven_coordinates)]
+    # include runtime output jars
+    elif target[JavaInfo].runtime_output_jars:
+        jars = target[JavaInfo].runtime_output_jars
+        source_jars = target[JavaInfo].source_jars
+        dependencies = [
+            struct(
+                type="jar",
+                class_jar=jar,
+                source_jar=source_jar,
+            )
+            for (jar, source_jar) in zip(
+                jars, source_jars + [None] * (len(jars) - len(source_jars))
+            )
+        ]
+    else:
+        fail("Unsure how to package dependency for target: %s" % target)
+
+    return JarInfo(
+        name=maven_coordinates,
+        deps=depset(
+            dependencies,
+            transitive=[
+                # Filter transitive JARs from dependency that has maven coordinates
+                # because those dependencies will already include the JARs as part
+                # of their classpath
+                depset(
+                    [dep for dep in target[JarInfo].deps.to_list() if dep.type == "pom"]
+                )
+                if target[JarInfo].name
+                else target[JarInfo].deps
+                for target in deps_all
+            ],
+        ),
+    )
+
+
+aggregate_dependency_info = aspect(
+    attr_aspects=[
+        "jars",
+        "deps",
+        "exports",
+        "runtime_deps",
+    ],
+    doc="Collects the Maven coordinates of the given java_library, its direct dependencies, and its transitive dependencies",
+    implementation=_aggregate_dependency_info_impl,
+    provides=[JarInfo],
+)
+
+jvm_export = rule(
+    attrs={
+        "target": attr.label(
+            mandatory=True,
+            aspects=[
+                aggregate_dependency_info,
+            ],
+            doc="Java target for subsequent deployment",
+        ),
+        "version": attr.label(
+            doc="""
+            A target that represents version string.
+            Alternatively, pass --@twitter_rules_jvm_export//jvm_export:version=0.1.0
+            to Bazel invocation.
+            """,
+            default="@twitter_rules_jvm_export//jvm_export:version",
+            providers=[VersionInfo],
+        ),
+        "version_overrides": attr.string_dict(
+            default={},
+            doc="Dictionary of maven artifact : version to pin artifact versions to",
+        ),
+        "project_name": attr.string(
+            mandatory=True,
+            doc="Project name to fill into pom.xml",
+        ),
+        "project_description": attr.string(
+            default="PROJECT_DESCRIPTION",
+            doc="Project description to fill into pom.xml",
+        ),
+        "project_url": attr.string(
+            default="PROJECT_URL",
+            doc="Project URL to fill into pom.xml",
+        ),
+        "license": attr.string(
+            values=["Apache-2.0", "MIT"],
+            default="Apache-2.0",
+            doc="Project license to fill into pom.xml",
+        ),
+        "scm_url": attr.string(
+            default="PROJECT_URL",
+            doc="Project source control URL to fill into pom.xml",
+        ),
+        "snapshot_repo": attr.string(
+            mandatory=True,
+            doc="Snapshot repository to release maven artifacts",
+        ),
+        "release_repo": attr.string(
+            mandatory=True,
+            doc="Release repository to release maven artifacts",
+        ),
+        "python_path": attr.string(
+            default="/usr/bin/env python",
+            doc="Path to python command",
+        ),
+        "assemble": attr.bool(
+            default=False,
+            doc="Aggregate JAR files into one über JAR",
+        ),
+        "_pom_generator": attr.label(
+            default="@twitter_rules_jvm_export//jvm_export/support:pom_generator.py",
+            executable=True,
+            allow_single_file=True,
+            cfg="host",
+        ),
+        "_jar_assembler": attr.label(
+            default="@twitter_rules_jvm_export//jvm_export/support:jar_assembler.py",
+            executable=True,
+            allow_single_file=True,
+            cfg="host",
+        ),
+        "_deployment": attr.label(
+            allow_single_file=True,
+            default="@twitter_rules_jvm_export//jvm_export/support:deploy.py",
+        ),
+    },
+    executable=True,
+    implementation=_jvm_export_impl,
+    doc="Publish Java package to a Maven repo",
+)
+
+
+def _jvm_export_version_impl(ctx):
+    value = ctx.build_setting_value
+    return VersionInfo(value=value)
+
+
+_jvm_export_version = rule(
+    implementation=_jvm_export_version_impl,
+    build_setting=config.string(flag=True),
+    doc="Version used to publish JVM artifacts",
+)
+
+
+def jvm_export_version(name, version):
+    return _jvm_export_version(
+        name=name,
+        build_setting_default=version,
+        visibility=["//visibility:public"],
+    )

--- a/rules_jvm_export/jvm_export/support/BUILD
+++ b/rules_jvm_export/jvm_export/support/BUILD
@@ -1,0 +1,1 @@
+exports_files(["deploy.py", "jar_assembler.py", "pom_generator.py"])

--- a/rules_jvm_export/jvm_export/support/deploy.py
+++ b/rules_jvm_export/jvm_export/support/deploy.py
@@ -1,0 +1,264 @@
+#!$PYTHON_PATH
+
+# Originally from https://github.com/vaticle/bazel-distribution/blob/master/maven/templates/deploy.py
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import print_function
+from xml.etree import ElementTree
+
+import argparse
+import hashlib
+import os
+import re
+import shutil
+import subprocess as sp
+import sys
+import tempfile
+from pathlib import Path
+from posixpath import join as urljoin
+from urllib.parse import urlparse
+
+USAGE_STR = """
+bazel run <target>.publish -- release
+"""
+
+MAVEN_REPOS = {
+    "snapshot": "{snapshot}",
+    "release": "{release}",
+    "local": "file:~/.m2/repository/",
+}
+JAR_PATH = "$JAR_PATH"
+POM_FILE_PATH = "$POM_PATH"
+SRCJAR_PATH = "$SRCJAR_PATH"
+
+
+def main():
+    args = _parse_args()
+    repo_type = "local" if args.local else args.command
+    maven_url = MAVEN_REPOS[repo_type]
+    pom = ElementTree.parse(POM_FILE_PATH).getroot()
+    group_id = _parse_pom(pom, "ns0:groupId")
+    artifact_id = _parse_pom(pom, "ns0:artifactId")
+    version = _parse_pom(pom, "ns0:version")
+    version_snapshot_regex = """^[0-9|a-f|A-F]{40}$|.*-SNAPSHOT$"""
+    version_release_regex = """^[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)*$"""
+    if (
+        repo_type == "snapshot"
+        and len(re.findall(version_snapshot_regex, version)) == 0
+    ):
+        raise ValueError(
+            "Invalid version: {}. An artifact uploaded to a {} repository "
+            "must have a version which complies to this regex: {}".format(
+                version, repo_type, version_snapshot_regex
+            )
+        )
+    if repo_type == "release" and len(re.findall(version_release_regex, version)) == 0:
+        raise ValueError(
+            "Invalid version: {}. An artifact uploaded to a {} repository "
+            "must have a version which complies to this regex: {}".format(
+                version, repo_type, version_release_regex
+            )
+        )
+    curl_opts = _curl_options(maven_url, args.netrc)
+
+    filename_base = "{coordinates}/{artifact}/{version}/{artifact}-{version}".format(
+        coordinates=group_id.replace(".", "/"), version=version, artifact=artifact_id
+    )
+
+    upload(maven_url, curl_opts, JAR_PATH, filename_base + ".jar")
+    if args.gpg:
+        upload(maven_url, curl_opts, sign(JAR_PATH), filename_base + ".jar.asc")
+    upload(maven_url, curl_opts, POM_FILE_PATH, filename_base + ".pom")
+    if args.gpg:
+        upload(maven_url, curl_opts, sign(POM_FILE_PATH), filename_base + ".pom.asc")
+    if os.path.exists(SRCJAR_PATH):
+        upload(maven_url, curl_opts, SRCJAR_PATH, filename_base + "-sources.jar")
+        if args.gpg:
+            upload(
+                maven_url,
+                curl_opts,
+                sign(SRCJAR_PATH),
+                filename_base + "-sources.jar.asc",
+            )
+        # TODO(vmax): use real Javadoc instead of srcjar
+        upload(maven_url, curl_opts, SRCJAR_PATH, filename_base + "-javadoc.jar")
+        if args.gpg:
+            upload(
+                maven_url,
+                curl_opts,
+                sign(SRCJAR_PATH),
+                filename_base + "-javadoc.jar.asc",
+            )
+
+    with tempfile.NamedTemporaryFile(mode="wt", delete=True) as pom_md5:
+        pom_md5.write(md5(POM_FILE_PATH))
+        pom_md5.flush()
+        upload(maven_url, curl_opts, pom_md5.name, filename_base + ".pom.md5")
+
+    with tempfile.NamedTemporaryFile(mode="wt", delete=True) as pom_sha1:
+        pom_sha1.write(sha1(POM_FILE_PATH))
+        pom_sha1.flush()
+        upload(maven_url, curl_opts, pom_sha1.name, filename_base + ".pom.sha1")
+
+    with tempfile.NamedTemporaryFile(mode="wt", delete=True) as jar_md5:
+        jar_md5.write(md5(JAR_PATH))
+        jar_md5.flush()
+        upload(maven_url, curl_opts, jar_md5.name, filename_base + ".jar.md5")
+
+    with tempfile.NamedTemporaryFile(mode="wt", delete=True) as jar_sha1:
+        jar_sha1.write(sha1(JAR_PATH))
+        jar_sha1.flush()
+        upload(maven_url, curl_opts, jar_sha1.name, filename_base + ".jar.sha1")
+
+    if os.path.exists(SRCJAR_PATH):
+        with tempfile.NamedTemporaryFile(mode="wt", delete=True) as srcjar_md5:
+            srcjar_md5.write(md5(SRCJAR_PATH))
+            srcjar_md5.flush()
+            upload(
+                maven_url,
+                curl_opts,
+                srcjar_md5.name,
+                filename_base + "-sources.jar.md5",
+            )
+            # TODO(vmax): use checksum of real Javadoc instead of srcjar
+            upload(
+                maven_url,
+                curl_opts,
+                srcjar_md5.name,
+                filename_base + "-javadoc.jar.md5",
+            )
+
+        with tempfile.NamedTemporaryFile(mode="wt", delete=True) as srcjar_sha1:
+            srcjar_sha1.write(sha1(SRCJAR_PATH))
+            srcjar_sha1.flush()
+            upload(
+                maven_url,
+                curl_opts,
+                srcjar_sha1.name,
+                filename_base + "-sources.jar.sha1",
+            )
+            # TODO(vmax): use checksum of real Javadoc instead of srcjar
+            upload(
+                maven_url,
+                curl_opts,
+                srcjar_sha1.name,
+                filename_base + "-javadoc.jar.sha1",
+            )
+
+
+def _parse_pom(pom, elem_name):
+    namespaces = {"ns0": "http://maven.apache.org/POM/4.0.0"}
+    elem = pom.find(elem_name, namespaces)
+    if elem is None or len(elem.text) == 0:
+        raise Exception(f"Could not get {elem_name} from pom.xml")
+    return elem.text
+
+
+def sha1(fn):
+    with open(fn, "rb") as f:
+      return hashlib.sha1(f.read()).hexdigest()
+
+
+def md5(fn):
+    with open(fn, "rb") as f:
+        return hashlib.md5(f.read()).hexdigest()
+
+
+def upload(url, curl_opts, local_fn, remote_fn):
+    print(f"  publishing {remote_fn}")
+    u = urlparse(url)
+    if u.scheme == "file":
+        destination = Path(u.path).expanduser() / remote_fn
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src=local_fn, dst=destination)
+    else:
+        failed = False
+        try:
+            upload_status_code = (
+                sp.check_output(
+                    [
+                        "curl",
+                        "--silent",
+                        "--output",
+                        "/dev/stderr",
+                        "--write-out",
+                        "%{http_code}",
+                        *curl_opts,
+                        "--upload-file",
+                        local_fn,
+                        urljoin(url, remote_fn),
+                    ]
+                )
+                .decode()
+                .strip()
+            )
+        except Exception:
+            # Catch the exception to avoid credential getting logged
+            failed = True
+        if failed:
+            raise Exception("upload of {} to {} failed".format(local_fn, urljoin(url, remote_fn)))
+        if upload_status_code not in {"200", "201"}:
+            raise Exception(
+                "upload of {} failed, got HTTP status code {}".format(
+                    local_fn, upload_status_code
+                )
+            )
+
+
+def sign(fn):
+    # TODO(vmax): current limitation of this functionality
+    # is that gpg key should already be present in keyring
+    # and should not require passphrase
+    asc_file = tempfile.mktemp()
+    sp.check_call(["gpg", "--detach-sign", "--armor", "--output", asc_file, fn])
+    return asc_file
+
+
+def _curl_options(maven_url, netrc):
+    if urlparse(maven_url).scheme == "file":
+        return None
+    elif netrc:
+        return ["--netrc"]
+    else:
+        username, password = os.getenv("SONATYPE_USERNAME"), os.getenv(
+            "SONATYPE_PASSWORD"
+        )
+        if not username:
+            raise ValueError(
+                "Error: username should be passed via $SONATYPE_USERNAME env variable"
+            )
+        if not password:
+            raise ValueError(
+                "Error: password should be passed via $SONATYPE_PASSWORD env variable"
+            )
+        return ["-u", f"{username}:{password}"]
+
+
+def _parse_args():
+    class Formatter(
+        argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter
+    ):
+        pass
+
+    parser = argparse.ArgumentParser(description=USAGE_STR, formatter_class=Formatter)
+    parser.add_argument("command", choices=["release", "snapshot"])
+    parser.add_argument(
+        "--gpg", action="store_true", default=False, help="Sign artifact using gpg"
+    )
+    parser.add_argument(
+        "--netrc",
+        action="store_true",
+        default=False,
+        help="Use .netrc for authentication",
+    )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        default=False,
+        help="Publish to local M2 repo (~/.m2/repository/).",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/rules_jvm_export/jvm_export/support/jar_assembler.py
+++ b/rules_jvm_export/jvm_export/support/jar_assembler.py
@@ -1,0 +1,48 @@
+#!$PYTHON_PATH
+
+import argparse
+from pathlib import Path
+import zipfile
+from zipfile import ZipFile
+
+USAGE_STR = """This program aggregates JAR files for publishing to Maven.
+"""
+
+
+def main():
+    args = _parse_args()
+    print(str(args.jars))
+    with ZipFile(args.output, "w") as output:
+        if args.pom_file:
+            pom_path = f"META-INF/maven/{args.group_id}/{args.artifact_id}/pom.xml"
+            output.write(args.pom_file, pom_path)
+        for jar_file in args.jars:
+            with ZipFile(jar_file, "r") as jar:
+                for entry in jar.infolist():
+                    if entry.is_dir():
+                        pass
+                    elif entry.filename.startswith("META-INF/MANIFEST.MF"):
+                        pass
+                    elif entry.filename.startswith("META-INF/maven/"):
+                        pass
+                    else:
+                        output.writestr(entry, entry.filename)
+
+
+def _parse_args():
+    class Formatter(
+        argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter
+    ):
+        pass
+
+    parser = argparse.ArgumentParser(description=USAGE_STR, formatter_class=Formatter)
+    parser.add_argument("--output", required=True, type=str)
+    parser.add_argument("--group_id", type=str)
+    parser.add_argument("--artifact_id", type=str)
+    parser.add_argument("--pom_file", type=Path)
+    parser.add_argument("jars", nargs="+", type=Path)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/rules_jvm_export/jvm_export/support/pom_generator.py
+++ b/rules_jvm_export/jvm_export/support/pom_generator.py
@@ -1,0 +1,119 @@
+#!$PYTHON_PATH
+
+import argparse
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+
+USAGE_STR = """This program generates POM file for publishing to Maven.
+"""
+
+
+def main():
+    args = _parse_args()
+    version = args.version
+    ET.register_namespace("", "http://maven.apache.org/POM/4.0.0")
+    ET.register_namespace("xsi", "http://www.w3.org/2001/XMLSchema-instance")
+    pom = ET.Element(
+        "{http://maven.apache.org/POM/4.0.0}project",
+        attrib={
+            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+            "xsi:schemaLocation": "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd",
+        },
+    )
+    pom.append(_elem_text("modelVersion", "4.0.0"))
+    pom.append(_elem_text("name", args.project_name))
+    pom.append(_elem_text("description", args.project_description))
+    pom.append(_elem_text("url", args.project_url))
+    pom.append(_licenses(args))
+    pom.append(_scm(args))
+    pom.append(_elem_text("groupId", args.group_id))
+    pom.append(_elem_text("artifactId", args.artifact_id))
+    pom.append(_elem_text("version", version))
+    pom.append(_dependencies(args, version))
+    with open(args.output_file, "w") as f:
+        f.write(_pretty_print(pom))
+
+
+def _dependencies(args, version):
+    dependencies = ET.Element("dependencies")
+    coordinates = (
+        args.target_deps_coordinates.split(";") if args.target_deps_coordinates else []
+    )
+    for dep in coordinates:
+        dep_group, dep_name, dep_version = _parse_maven_coordinates(dep)
+        dependency = ET.Element("dependency")
+        dependency.append(_elem_text("groupId", dep_group))
+        dependency.append(_elem_text("artifactid", dep_name))
+        dependency.append(_elem_text("version", dep_version))
+        dependencies.append(dependency)
+    return dependencies
+
+
+def _parse_maven_coordinates(coord):
+    xs = coord.split(":")
+    return xs[0], xs[1], xs[2]
+
+
+def _licenses(args):
+    licenses = ET.Element("licenses")
+    license = ET.Element("license")
+    info = _get_license_info(args.license)
+    license.append(_elem_text("name", info["name"]))
+    license.append(_elem_text("url", info["url"]))
+    licenses.append(license)
+    return licenses
+
+
+def _get_license_info(license):
+    if license == "apache" or license == "Apache-2.0":
+        return {
+            "name": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+        }
+    if license == "mit" or license == "MIT":
+        return {
+            "name": "MIT",
+            "url": "https://opensource.org/licenses/MIT",
+        }
+    raise ValueError("expected Apache-2.0 or MIT")
+
+
+def _scm(args):
+    scm = ET.Element("scm")
+    scm.append(_elem_text("connection", args.scm_url))
+    scm.append(_elem_text("url", args.scm_url))
+    return scm
+
+
+def _elem_text(name, text):
+    child = ET.Element(name)
+    child.text = text
+    return child
+
+
+def _pretty_print(elem):
+    return minidom.parseString(ET.tostring(elem)).toprettyxml(indent="  ")
+
+
+def _parse_args():
+    class Formatter(
+        argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter
+    ):
+        pass
+
+    parser = argparse.ArgumentParser(description=USAGE_STR, formatter_class=Formatter)
+    parser.add_argument("--group_id", type=str, required=True)
+    parser.add_argument("--artifact_id", type=str, required=True)
+    parser.add_argument("--version", type=str, required=True)
+    parser.add_argument("--project_name", type=str)
+    parser.add_argument("--project_description", type=str)
+    parser.add_argument("--project_url", type=str)
+    parser.add_argument("--license", type=str)
+    parser.add_argument("--scm_url", type=str)
+    parser.add_argument("--target_deps_coordinates", type=str, default="")
+    parser.add_argument("--output_file", type=str)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+
+# Exit on error. Append "|| true" if you expect an error.
+set -o errexit
+# Exit on error inside any functions or subshells.
+set -o errtrace
+# Do not allow use of undefined vars. Use ${VAR:-} to use an undefined VAR
+set -o nounset
+# Catch the error in case mysqldump fails (but gzip succeeds) in `mysqldump |gzip`
+set -o pipefail
+# Turn on traces, useful while debugging but commented out by default
+# set -o xtrace
+
+cd multiversion-example
+bazel build tricky/...
+
+rm -rf $HOME/.m2/repository/com/twitter/dpb/
+bazel run export-example:io1.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release --local
+ls $HOME/.m2/repository/com/twitter/dpb/io1/0.1.0-alpha1/io1-0.1.0-alpha1.pom
+cat $HOME/.m2/repository/com/twitter/dpb/io1/0.1.0-alpha1/io1-0.1.0-alpha1.pom | grep "29\.0"
+
+ls $HOME/.m2/repository/com/twitter/dpb/io1/0.1.0-alpha1/io1-0.1.0-alpha1.jar
+ls $HOME/.m2/repository/com/twitter/dpb/io1/0.1.0-alpha1/io1-0.1.0-alpha1-sources.jar
+ls $HOME/.m2/repository/com/twitter/dpb/io1/0.1.0-alpha1/io1-0.1.0-alpha1-javadoc.jar


### PR DESCRIPTION
This implements rules_jvm_export, a Bazel rule to publish build artifacts to a Maven repository.
Given that there's already [vaticle/bazel-distribution][1] rule, why make another one?
The Maven-related rules in bazel-distribution are good foundation so we are basing this rule off of them, but they do things that we don't need, and don't do certain things we do want. Here are the main differences:

- bazel-distribution uses Kotlin and Python to implement helper programs.
  This requires rules_kotlin to be introduced to `WORKSPACE`.
  rules_jvm_export only uses Python instead.
- bazel-distribution creates an über JAR in the `assemble_maven(...)` rule,
  which includes classes coming from the dependencies.
  The jar_assembler seems to skip over `META-INF`, potentially losing info.
  rules_jvm_export by default uses the normal `build` artifacts.
- rules_jvm_export just needs one target `jvm_export(...)` instead of
  `assemble_maven(...)` and `deploy_maven(...)`, in part because we're
  not creating assembly JAR by default.
  This is similar to rules_jvm_external's approach.
- bazel-distribution uses a text file called `VERSION` to track the
  version number. rules_jvm_export introduces
  `jvm_export_version(...)` setting to track version numbers.
  These can be overridden from the command line without using `--define`.

Here are the new features:

- Support for bazel-multiversion 3rdparty targets.
- `--netrc` option to use `.netrc` for authentication instead of
  environment variables.
- rules_jvm_export supports file copying to local M2 repo.
  `--local` option can be passed to `bazel run` to publish to M2.

## Usage

```python
load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
load("@twitter_rules_jvm_export//jvm_export:jvm_export.bzl", "jvm_export")
scala_library(
    name = "io1",
    srcs = ["IO1.scala"],
    tags = [
        "maven_coordinates=com.example:io1:{pom_version}",
    ],
    deps = [
        "@maven//:3rdparty/jvm/com/google/guava/guava",
    ],
)
jvm_export(
    name = "io1.publish",
    target = ":io1",
    project_name = "IO 1",
    project_description = "IO library",
    project_url = "http://example.com/",
    license = "Apache-2.0",
    scm_url = "http://github.com/",
    release_repo = "https://localhost/",
    snapshot_repo = "https://localhost/",
    python_path = "/usr/bin/env python",
)
```

To publish using `.netrc` authentication:

```bash
$ bazel run //:io1.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release --netrc
```

To publish with environment variable authentication, set `SONATYPE_USERNAME` and `SONATYPE_PASSWORD`, then run:

```bash
$ bazel run //:io1.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release
```

To publish to local `~/.m2/repository/`:

```bash
$ bazel run //:io1.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release --local
```

  [1]: https://github.com/vaticle/bazel-distribution