### PR TITLE
classifier support 

### DIFF
--- a/multiversion-example/export-example/BUILD
+++ b/multiversion-example/export-example/BUILD
@@ -14,7 +14,7 @@ scala_library(
 
 jvm_export(
     name = "io1.publish",
-    target = ":io1",
+    artifacts = [":io1"],
     project_name = "IO 1",
     project_description = "IO library",
     project_url = "http://example.com/",
@@ -36,7 +36,7 @@ jvm_assembly(
 
 jvm_export(
     name = "io1.assembly.publish",
-    target = ":io1.assembly",
+    artifacts = [":io1.assembly"],
     project_name = "IO 1",
     project_description = "IO library",
     project_url = "http://example.com/",
@@ -51,7 +51,7 @@ scala_library(
     name = "io2",
     srcs = ["IO2.scala"],
     tags = [
-        "maven_coordinates=com.twitter.dpb:io2:{pom_version}",
+        "maven_coordinates=com.twitter.dpb:io2:jar:abc:{pom_version}",
     ],
     deps = [
         ":io1",
@@ -60,8 +60,32 @@ scala_library(
 
 jvm_export(
     name = "io2.publish",
-    target = ":io2",
+    artifacts = [":io2"],
     project_name = "IO 2",
+    project_description = "IO library",
+    project_url = "http://example.com/",
+    license = "Apache-2.0",
+    scm_url = "http://github.com/",
+    release_repo = "https://localhost/",
+    snapshot_repo = "https://localhost/",
+    # python_path = "/opt/ee/python/3.10/bin/python3.10",
+)
+
+scala_library(
+    name = "io3",
+    srcs = ["IO3.scala"],
+    tags = [
+        "maven_coordinates=com.twitter.dpb:io3:jar:abc:{pom_version}",
+    ],
+    deps = [
+        ":io2",
+    ],
+)
+
+jvm_export(
+    name = "io3.publish",
+    artifacts = [":io3"],
+    project_name = "IO 3",
     project_description = "IO library",
     project_url = "http://example.com/",
     license = "Apache-2.0",

--- a/multiversion-example/export-example/IO3.scala
+++ b/multiversion-example/export-example/IO3.scala
@@ -1,0 +1,3 @@
+package com.twitter.dpb
+
+case class IO3()

--- a/rules_jvm_export/README.md
+++ b/rules_jvm_export/README.md
@@ -20,7 +20,7 @@ scala_library(
 
 jvm_export(
     name = "io1.publish",
-    target = ":io1",
+    artifacts = [":io1"],
     project_name = "IO 1",
     project_description = "IO library",
     project_url = "http://example.com/",

--- a/rules_jvm_export/jvm_export/jvm_assembly.bzl
+++ b/rules_jvm_export/jvm_export/jvm_assembly.bzl
@@ -63,14 +63,18 @@ def jar_assembler(ctx):
 
 
 def runtime_output_jar(target):
-    if len(target[JavaInfo].runtime_output_jars) == 1:
-        return target[JavaInfo].runtime_output_jars[0]
-    else:
-        fail(
-            "expected size 1, but runtime_output_jars in {} was {}".format(
-                target, target[JavaInfo].runtime_output_jars
+    if JavaInfo in target:
+        if len(target[JavaInfo].runtime_output_jars) == 1:
+            return target[JavaInfo].runtime_output_jars[0]
+        else:
+            fail(
+                "expected size 1, but runtime_output_jars in {} was {}".format(
+                    target, target[JavaInfo].runtime_output_jars
+                )
             )
-        )
+    else:
+        outputs = target[DefaultInfo].files.to_list()
+        return outputs[0]
 
 
 def generate_class_jar(ctx, pom_file):

--- a/rules_jvm_export/jvm_export/jvm_export.bzl
+++ b/rules_jvm_export/jvm_export/jvm_export.bzl
@@ -41,10 +41,11 @@ def _jvm_export_impl(ctx):
         artifacts[classifier] = class_jar.basename
         if not classifier:
             source_jar = _source_jar(artifact)
-            output_files.append(source_jar)
-            src_jar_link = "lib.srcjar"
-            symlinks[src_jar_link] = source_jar
-            artifacts[SOURCES_CLASSIFIER] = src_jar_link
+            if source_jar:
+                output_files.append(source_jar)
+                src_jar_link = "lib.srcjar"
+                symlinks[src_jar_link] = source_jar
+                artifacts[SOURCES_CLASSIFIER] = src_jar_link
 
     # TODO(vmax): use real Javadoc instead of srcjar
     if (SOURCES_CLASSIFIER in artifacts) and (JAVADOC_CLASSIFIER not in artifacts):
@@ -65,10 +66,6 @@ def _jvm_export_impl(ctx):
             "{release}": ctx.attr.release_repo,
         },
     )
-    if source_jar:
-        output_files.append(source_jar)
-        symlinks[src_jar_link] = source_jar
-
     return [
         DefaultInfo(
             executable=deploy_script,
@@ -155,10 +152,10 @@ def _generate_pom_file(ctx, version):
 
 
 def _source_jar(target):
-    if len(target[JavaInfo].source_jars) < 1:
-        fail("Could not find source JAR to deploy in {}".format(target))
-    else:
+    if JavaInfo in target:
         return target[JavaInfo].source_jars[0]
+    else:
+        return None
 
 
 def make_jvm_export_rule():

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -27,3 +27,5 @@ ls /tmp/repo/com/twitter/dpb/io1/0.1.0-alpha1/io1-0.1.0-alpha1-javadoc.jar
 
 bazel run export-example:io2.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release --publish_to=/tmp/repo
 cat /tmp/repo/com/twitter/dpb/io2/0.1.0-alpha1/io2-0.1.0-alpha1.pom | tr -d ' ' | tr -d '\n' | grep '<dependency><groupId>com.twitter.dpb</groupId><artifactId>io1</artifactId><version>0.1.0-alpha1</version></dependency>'
+bazel run export-example:io3.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release --publish_to=/tmp/repo
+cat /tmp/repo/com/twitter/dpb/io3/0.1.0-alpha1/io3-0.1.0-alpha1.pom | tr -d ' ' | tr -d '\n' | grep '<dependency><groupId>com.twitter.dpb</groupId><artifactId>io2</artifactId><classifier>abc</classifier><version>0.1.0-alpha1</version></dependency>'


### PR DESCRIPTION
Problem
-------
Publishing doesn't support custom classifiers.

Solution
--------
Add classifier publishing by letting the build user encode the
information into the maven_coordinates tag.
For example, to publish a JAR file as `abc` classifier, tag it as
`maven_coordinates=com.twitter.dpb:io3:jar:abc:{pom_version}`.
`jvm_export(...)` will pick that up to publish it with `-abc.jar` name.