### PR TITLE
Encode provided scope as neverlink

### DIFF
--- a/multiversion-example/export-example/BUILD
+++ b/multiversion-example/export-example/BUILD
@@ -94,3 +94,49 @@ jvm_export(
     snapshot_repo = "https://localhost/",
     # python_path = "/opt/ee/python/3.10/bin/python3.10",
 )
+
+scala_library(
+    name = "io4",
+    srcs = ["IO4.scala"],
+    tags = [
+        "maven_coordinates=com.twitter.dpb:io4:{pom_version}",
+    ],
+    neverlink = True,
+)
+
+jvm_export(
+    name = "io4.publish",
+    artifacts = [":io4"],
+    project_name = "IO 4",
+    project_description = "IO library",
+    project_url = "http://example.com/",
+    license = "Apache-2.0",
+    scm_url = "http://github.com/",
+    release_repo = "https://localhost/",
+    snapshot_repo = "https://localhost/",
+    # python_path = "/opt/ee/python/3.10/bin/python3.10",
+)
+
+scala_library(
+    name = "io5",
+    srcs = ["IO5.scala"],
+    tags = [
+        "maven_coordinates=com.twitter.dpb:io5:{pom_version}",
+    ],
+    deps = [
+        ":io4",
+    ],
+)
+
+jvm_export(
+    name = "io5.publish",
+    artifacts = [":io5"],
+    project_name = "IO 5",
+    project_description = "IO library",
+    project_url = "http://example.com/",
+    license = "Apache-2.0",
+    scm_url = "http://github.com/",
+    release_repo = "https://localhost/",
+    snapshot_repo = "https://localhost/",
+    # python_path = "/opt/ee/python/3.10/bin/python3.10",
+)

--- a/multiversion-example/export-example/IO4.scala
+++ b/multiversion-example/export-example/IO4.scala
@@ -1,0 +1,3 @@
+package com.twitter.dpb
+
+case class IO4()

--- a/multiversion-example/export-example/IO5.scala
+++ b/multiversion-example/export-example/IO5.scala
@@ -1,0 +1,3 @@
+package com.twitter.dpb
+
+case class IO5()

--- a/rules_jvm_export/jvm_export/jvm_assembly.bzl
+++ b/rules_jvm_export/jvm_export/jvm_assembly.bzl
@@ -185,6 +185,7 @@ JarInfo = provider(
         "name": "The name of a the JAR (Maven coordinates)",
         "deps": "Direct dependencies",
         "jar_infos": "The list of dependencies of this JAR. A dependency may be of two types, POM or JAR.",
+        "neverlink": "Forward neverlink from target",
     },
 )
 
@@ -195,6 +196,7 @@ def _aggregate_dependency_info_impl(target, ctx):
     runtime_deps = getattr(ctx.rule.attr, "runtime_deps", [])
     exports = getattr(ctx.rule.attr, "exports", [])
     deps_all = deps + exports + runtime_deps
+    neverlink = getattr(ctx.rule.attr, "neverlink", False)
 
     maven_coordinates = find_maven_coordinates(target, tags)
     dependencies = []
@@ -238,6 +240,7 @@ def _aggregate_dependency_info_impl(target, ctx):
                 for jar in deps_all
             ],
         ),
+        neverlink=neverlink,
     )
 
 

--- a/rules_jvm_export/jvm_export/jvm_export.bzl
+++ b/rules_jvm_export/jvm_export/jvm_export.bzl
@@ -108,6 +108,9 @@ def _generate_pom_file(ctx, version):
             pom_dependency_version = pom_dependency_coordinates.version
             pom_dependency_classifier = getattr(pom_dependency_coordinates, "classifier", "")
             pom_dependency_packaging = getattr(pom_dependency_coordinates, "packaging", "jar")
+            pom_dependency_neverlink = getattr(pom_dependency, "neverlink", False)
+            if pom_dependency_neverlink:
+                pom_dependency_classifier = "provided"
             v = ctx.attr.version_overrides.get(
                 pom_dependency_artifact, pom_dependency_version
             )

--- a/rules_jvm_export/jvm_export/support/pom_generator.py
+++ b/rules_jvm_export/jvm_export/support/pom_generator.py
@@ -8,6 +8,9 @@ USAGE_STR = """This program generates POM file for publishing to Maven.
 """
 
 
+MAVEN_SCOPES = ["comiple", "provided", "runtime", "test"]
+
+
 def main():
     args = _parse_args()
     version = args.version
@@ -46,7 +49,11 @@ def _dependencies(args, version):
         dependency.append(_elem_text("groupId", dep_coord["group_id"]))
         dependency.append(_elem_text("artifactId", dep_coord["artifact_id"]))
         if "classifier" in dep_coord:
-            dependency.append(_elem_text("classifier", dep_coord["classifier"]))
+            dep_classifier = dep_coord["classifier"]
+            if dep_classifier in MAVEN_SCOPES:
+                dependency.append(_elem_text("scope", dep_classifier))
+            else:
+                dependency.append(_elem_text("classifier", dep_classifier))
 
         dependency.append(_elem_text("version", dep_version))
         dependencies.append(dependency)

--- a/rules_jvm_export/jvm_export/support/pom_generator.py
+++ b/rules_jvm_export/jvm_export/support/pom_generator.py
@@ -8,7 +8,7 @@ USAGE_STR = """This program generates POM file for publishing to Maven.
 """
 
 
-MAVEN_SCOPES = ["comiple", "provided", "runtime", "test"]
+MAVEN_SCOPES = ["compile", "provided", "runtime", "test"]
 
 
 def main():

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -29,3 +29,5 @@ bazel run export-example:io2.publish --@twitter_rules_jvm_export//jvm_export:ver
 cat /tmp/repo/com/twitter/dpb/io2/0.1.0-alpha1/io2-0.1.0-alpha1.pom | tr -d ' ' | tr -d '\n' | grep '<dependency><groupId>com.twitter.dpb</groupId><artifactId>io1</artifactId><version>0.1.0-alpha1</version></dependency>'
 bazel run export-example:io3.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release --publish_to=/tmp/repo
 cat /tmp/repo/com/twitter/dpb/io3/0.1.0-alpha1/io3-0.1.0-alpha1.pom | tr -d ' ' | tr -d '\n' | grep '<dependency><groupId>com.twitter.dpb</groupId><artifactId>io2</artifactId><classifier>abc</classifier><version>0.1.0-alpha1</version></dependency>'
+bazel run export-example:io5.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release --publish_to=/tmp/repo
+cat /tmp/repo/com/twitter/dpb/io5/0.1.0-alpha1/io5-0.1.0-alpha1.pom | tr -d ' ' | tr -d '\n' | grep '<dependency><groupId>com.twitter.dpb</groupId><artifactId>io4</artifactId><scope>provided</scope><version>0.1.0-alpha1</version></dependency>'


### PR DESCRIPTION
Problem
-------
We want to emulate provided scope (compile scope in Pants) using neverlink, but the jvm_export rule is unaware of that.

Solution
--------
Track neverlink attribute in the aspect and send them into the Python script as if it's a classifier.