### PR TITLE
Add arg to specify input configuration in `export`

### DIFF
--- a/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
+++ b/multiversion/src/main/scala/multiversion/commands/ExportCommand.scala
@@ -56,6 +56,7 @@ import multiversion.resolvers.Sha256
 @CommandName("export")
 case class ExportCommand(
     lint: Boolean = true,
+    inputPath: Path = Paths.get("3rdparty.yaml"),
     outputPath: Path = Paths.get("/tmp", "jvm_deps.bzl"),
     cache: Option[Path] = None,
     @Inline
@@ -165,13 +166,15 @@ case class ExportCommand(
 
   private def parseThirdpartyConfig(): Result[ThirdpartyConfig] = {
     val configPath =
-      app.env.workingDirectory.resolve("3rdparty.yaml")
+      app.env.workingDirectory.resolve(inputPath)
     if (!Files.isRegularFile(configPath)) {
       ErrorResult(
         Diagnostic.error(
           s"no such file: $configPath\n\tTo fix this problem, change your working directory or create this file"
         )
       )
+    } else if (configPath.getFileName.toString.endsWith(".json")) {
+      ThirdpartyConfig.parseJson(Input.path(configPath))
     } else {
       ThirdpartyConfig.parseYaml(Input.path(configPath))
     }

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ load("@maven//:jvm_deps.bzl", "load_jvm_deps")
 load_jvm_deps()
 ```
 
-### YAML
+### YAML or JSON
 
 If you prefer to configure the dependencies in one file, create `3rdparty.yaml`
 at the root of monorepo instead
@@ -129,6 +129,13 @@ runt the following inside the `multiversion-example/` directory:
 
 ```sh
 $ multiversion export --output-path=3rdparty/jvm_deps.bzl
+```
+
+You can also specify a different path or format for the input configuration using
+`--input-path`:
+
+```sh
+$ multiversion export --input-path=config/3rdparty.json --output-path=3rdparty/jvm_deps.bzl
 ```
 
 ### Pants


### PR DESCRIPTION
Previously, the `export` command would always read its input from `3rdparty.yaml`. This commit adds a new parameter, `--input-path`, which configures where to read the 3rdparty configuration from.

If the input file name ends with `.json`, then a JSON parser is used, instead of the default YAML parser.