### PR TITLE
Downgrade CI to Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             java: 11
           - os: macos-latest
             java: 11

--- a/build.sbt
+++ b/build.sbt
@@ -4,16 +4,7 @@ lazy val V = new {
 }
 
 ThisBuild / organization := "com.twitter.multiversion"
-ThisBuild / version := {
-  val snapshotV = "0.1.0-SNAPSHOT"
-  val old = (ThisBuild / version).value
-  (sys.env.get("BUILD_VERSION") orElse sys.props.get("sbt.build.version")) match {
-    case Some(v) => v
-    case _ =>
-      if ((ThisBuild / isSnapshot).value) snapshotV
-      else old
-  }
-}
+ThisBuild / version := "0.2.3"
 ThisBuild / homepage := Some(url("https://github.com/twitter/bazel-multiversion"))
 ThisBuild / licenses := List(
   "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")


### PR DESCRIPTION
The current latest Ubuntu image on GitHub actions (22.04) is using a version of glibc that is too recent for running on some CentOS machines where we would like to run bazel-multiversion.

We downgrade CI so that the binaries it produces can be run on CentOS.