### PR TITLE
Fix `jvm_export` with no sources

### DIFF
--- a/multiversion-example/export-example/BUILD
+++ b/multiversion-example/export-example/BUILD
@@ -140,3 +140,24 @@ jvm_export(
     snapshot_repo = "https://localhost/",
     # python_path = "/opt/ee/python/3.10/bin/python3.10",
 )
+
+scala_library(
+    name = "no-sources",
+    srcs = [],
+    tags = [
+        "maven_coordinates=com.twitter.dpb:no-sources:{pom_version}",
+    ],
+)
+
+jvm_export(
+    name = "no-sources.publish",
+    artifacts = [":no-sources"],
+    project_name = "IO 6",
+    project_description = "IO library",
+    project_url = "http://example.com/",
+    license = "Apache-2.0",
+    scm_url = "http://github.com/",
+    release_repo = "https://localhost/",
+    snapshot_repo = "https://localhost/",
+    # python_path = "/opt/ee/python/3.10/bin/python3.10",
+)

--- a/rules_jvm_export/jvm_export/jvm_export.bzl
+++ b/rules_jvm_export/jvm_export/jvm_export.bzl
@@ -155,7 +155,7 @@ def _generate_pom_file(ctx, version):
 
 
 def _source_jar(target):
-    if JavaInfo in target:
+    if JavaInfo in target and target[JavaInfo].source_jars:
         return target[JavaInfo].source_jars[0]
     else:
         return None

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -31,3 +31,5 @@ bazel run export-example:io3.publish --@twitter_rules_jvm_export//jvm_export:ver
 cat /tmp/repo/com/twitter/dpb/io3/0.1.0-alpha1/io3-0.1.0-alpha1.pom | tr -d ' ' | tr -d '\n' | grep '<dependency><groupId>com.twitter.dpb</groupId><artifactId>io2</artifactId><classifier>abc</classifier><version>0.1.0-alpha1</version></dependency>'
 bazel run export-example:io5.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release --publish_to=/tmp/repo
 cat /tmp/repo/com/twitter/dpb/io5/0.1.0-alpha1/io5-0.1.0-alpha1.pom | tr -d ' ' | tr -d '\n' | grep '<dependency><groupId>com.twitter.dpb</groupId><artifactId>io4</artifactId><scope>provided</scope><version>0.1.0-alpha1</version></dependency>'
+
+bazel run export-example:no-sources.publish --@twitter_rules_jvm_export//jvm_export:version=0.1.0-alpha1 -- release --publish_to=/tmp/repo


### PR DESCRIPTION
Previously, `jvm_export` rules with no sources (eg. a library that serves as an umbrella for several libraries) would fail during analysis with the following error:

```
ERROR: /Users/me/work/lib/BUILD:60:14: in jvm_export rule //lib:lib.publish:
Traceback (most recent call last):
        File "(...)/jvm_export/jvm_export.bzl", line 43, column 37, in _jvm_export_impl
                source_jar = _source_jar(artifact)
        File "(...)/jvm_export/jvm_export.bzl", line 159, column 44, in _source_jar
                return target[JavaInfo].source_jars[0]
Error: index out of range (index is 0, but sequence has 0 elements)
```

With this patch, the rule will no longer try to find a sources jar that doesn't exist.