### PR TITLE
[Minor] Conform generated deps file to buildifier standard

### DIFF
--- a/multiversion/src/main/scala/multiversion/outputs/DepsOutput.scala
+++ b/multiversion/src/main/scala/multiversion/outputs/DepsOutput.scala
@@ -54,7 +54,7 @@ def load_jvm_deps():
     $httpFiles
 
 \"\"\"
-    ctx.file("jvm_deps.bzl", content, executable=False)
+    ctx.file("jvm_deps.bzl", content, executable = False)
     build_content = \"\"\"
 load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")
 
@@ -64,16 +64,16 @@ $builds
 
 $evictedBuilds
 \"\"\"
-    ctx.file("BUILD", build_content, executable=False)
+    ctx.file("BUILD", build_content, executable = False)
 
 
 jvm_deps_rule = repository_rule(
-    implementation=_jvm_deps_impl,
+    implementation = _jvm_deps_impl,
 )
 
 
 def jvm_deps():
-    jvm_deps_rule(name="maven")
+    jvm_deps_rule(name = "maven")
 """.stripMargin
   }
 }


### PR DESCRIPTION
Small and superficial change but wondering if you're open to having the generated file conform to the default buildifier functionality. Otherwise it tries to reformat it each time it updates.